### PR TITLE
feat(kb): non-interactive JSON CLI for Knowledge Base API

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ caipe config set auth.idp-hint duo-sso
 | `CAIPE_STREAM_PLAIN` | Set to `1` for legacy plain-text chunk streaming (no live markdown colors) |
 | `CAIPE_IDP_HINT` | Keycloak `kc_idp_hint` |
 | `CAIPE_TOKEN` | Bearer token (headless / CI) |
+| `CAIPE_KB_URL` | Knowledge Base RAG API base URL |
+| `CAIPE_TENANT_ID` | `X-Tenant-Id` for KB API calls (when not using default tenant) |
 | `CAIPE_API_KEY` | API key where supported |
 
 ### Auth troubleshooting
@@ -239,6 +241,27 @@ caipe auth logout
 
 **OAuth browser:** By default the CLI opens Chrome/Chromium with a **temporary profile** so logging in does not overwrite cookies for an open caipe-ui tab. Set `CAIPE_CHROMIUM_PATH` if Chrome is non-standard. `CAIPE_AUTH_BROWSER=system` restores the old behavior. `CAIPE_AUTH_HEADLESS=1` uses headless mode (often breaks MFA).
 
+### Knowledge Base (scripts / CI)
+
+Non-interactive commands talk to the [CAIPE RAG REST API](https://github.com/cnoe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag) and **always print JSON** to stdout (errors as JSON on stderr).
+
+```bash
+caipe config set kb.url https://your-kb-api.example.com   # or export CAIPE_KB_URL
+caipe auth login   # or export CAIPE_TOKEN / client credentials for CI
+
+caipe kb user info
+caipe kb datasources list
+caipe kb documents list <datasource-id> --limit 50
+caipe kb query --query "how do I deploy SSE?"
+caipe kb chunk get '<chunk-id>'
+
+caipe kb ingest url --url https://docs.example.com/
+caipe kb ingest file ./README.md ./guide.pdf --owner-team-slug my-team
+caipe kb job get <job-id>
+```
+
+Shared flags on `caipe kb`: `--kb-url`, `--token`, `--tenant-id` (or `CAIPE_TENANT_ID`).
+
 ---
 
 ## Configuration reference
@@ -249,6 +272,7 @@ caipe auth logout
 | `auth.url` | OAuth and discovery base (Keycloak realm URL or UI URL) |
 | `agent.default` | Default dynamic agent id for `caipe chat` when `--agent` is omitted |
 | `auth.idp-hint` | Skip Keycloak login chooser (`kc_idp_hint`) |
+| `kb.url` | Knowledge Base RAG REST API base URL |
 
 **Rich terminal output (interactive chat):** Markdown is rendered with **react-markdown** + **remark-gfm** as native Ink components (no ANSI markdown strings). Diffs use Ink colors. Block streaming caches completed sections in `<Static>`; the active tail updates in place. Tool runs show in the footer. Chat uses the **alternate screen** unless `CAIPE_NO_ALT_SCREEN=1` or `CAIPE_PLAIN_TERMINAL=1`. Legacy plain streaming: `CAIPE_STREAM_PLAIN=1`.
 | `auth.apiKey` | Static API key (headless alternative) |
@@ -266,6 +290,7 @@ caipe auth logout
 | `caipe auth login\|logout\|status` | OAuth session |
 | `caipe config set\|get\|unset\|discover` | Settings (`discover` sets `auth.url` via well-known URLs or Grid-style heuristics) |
 | `caipe agents list\|info` | Server agents |
+| `caipe kb …` | KB query, read chunks, ingest, jobs, RBAC (`user info`) — JSON only |
 | `caipe skills list\|install\|preview\|update` | Skill catalog |
 | `caipe memory` | Project memory files |
 | `caipe commit` | DCO-aware commit helper |

--- a/src/index.ts
+++ b/src/index.ts
@@ -333,7 +333,9 @@ kbJobCmd
     await runKbJobsByDatasource(datasourceId, kbCtx(opts));
   });
 
-const kbIngestCmd = kbCmd.command("ingest").description("Queue ingestion (requires ingest permission)");
+const kbIngestCmd = kbCmd
+  .command("ingest")
+  .description("Queue ingestion (requires ingest permission)");
 
 kbIngestCmd
   .command("url")

--- a/src/index.ts
+++ b/src/index.ts
@@ -229,6 +229,148 @@ agentsCmd
   });
 
 // ---------------------------------------------------------------------------
+// caipe kb (Knowledge Base — JSON output for scripts)
+// ---------------------------------------------------------------------------
+const kbCmd = program
+  .command("kb")
+  .description("Knowledge Base API (non-interactive JSON; ingestion, read, RBAC)")
+  .option("--kb-url <url>", "Override kb.url / CAIPE_KB_URL for this invocation")
+  .option("--token <jwt>", "Bearer JWT (or use CAIPE_TOKEN / OAuth session)")
+  .option("--tenant-id <id>", "X-Tenant-Id header (or CAIPE_TENANT_ID)");
+
+function kbCtx(cmdOpts: Record<string, unknown>): import("./kb/commands.js").KbCommandContextInput {
+  const globalOpts = program.opts() as { url?: string };
+  const parentOpts = kbCmd.opts() as {
+    kbUrl?: string;
+    token?: string;
+    tenantId?: string;
+  };
+  return {
+    authUrl: globalOpts.url,
+    kbUrl: (cmdOpts.kbUrl as string | undefined) ?? parentOpts.kbUrl,
+    token: (cmdOpts.token as string | undefined) ?? parentOpts.token,
+    tenantId:
+      (cmdOpts.tenantId as string | undefined) ??
+      parentOpts.tenantId ??
+      process.env.CAIPE_TENANT_ID,
+  };
+}
+
+const kbUserCmd = kbCmd.command("user").description("Current user and RBAC permissions");
+
+kbUserCmd
+  .command("info")
+  .description("GET /v1/user/info")
+  .action(async (opts: Record<string, unknown>) => {
+    const { runKbUserInfo } = await import("./kb/commands.js");
+    await runKbUserInfo(kbCtx(opts));
+  });
+
+const kbDsCmd = kbCmd.command("datasources").description("List knowledge sources");
+
+kbDsCmd
+  .command("list")
+  .description("GET /v1/datasources")
+  .action(async (opts: Record<string, unknown>) => {
+    const { runKbDatasourcesList } = await import("./kb/commands.js");
+    await runKbDatasourcesList(kbCtx(opts));
+  });
+
+const kbDocCmd = kbCmd.command("documents").description("Documents and chunks in a datasource");
+
+kbDocCmd
+  .command("list <datasourceId>")
+  .description("GET /v1/datasource/{id}/documents")
+  .option("--offset <n>", "Pagination offset", "0")
+  .option("--limit <n>", "Page size (max 1000)", "100")
+  .action(async (datasourceId: string, opts: Record<string, unknown>) => {
+    const { runKbDocumentsList } = await import("./kb/commands.js");
+    await runKbDocumentsList(datasourceId, {
+      ...kbCtx(opts),
+      offset: Number(opts.offset),
+      limit: Number(opts.limit),
+    });
+  });
+
+const kbChunkCmd = kbCmd.command("chunk").description("Fetch chunk payload");
+
+kbChunkCmd
+  .command("get <chunkId>")
+  .description("GET /v1/chunk/{id}/content")
+  .action(async (chunkId: string, opts: Record<string, unknown>) => {
+    const { runKbChunkGet } = await import("./kb/commands.js");
+    await runKbChunkGet(chunkId, kbCtx(opts));
+  });
+
+kbCmd
+  .command("query")
+  .description("POST /v1/query (semantic search)")
+  .requiredOption("--query <text>", "Search query")
+  .option("--limit <n>", "Max results", "10")
+  .action(async (opts: Record<string, unknown>) => {
+    const { runKbQuery } = await import("./kb/commands.js");
+    await runKbQuery(String(opts.query), {
+      ...kbCtx(opts),
+      limit: Number(opts.limit),
+    });
+  });
+
+const kbJobCmd = kbCmd.command("job").description("Ingestion job status");
+
+kbJobCmd
+  .command("get <jobId>")
+  .description("GET /v1/job/{id}")
+  .action(async (jobId: string, opts: Record<string, unknown>) => {
+    const { runKbJobGet } = await import("./kb/commands.js");
+    await runKbJobGet(jobId, kbCtx(opts));
+  });
+
+kbJobCmd
+  .command("list-by-datasource <datasourceId>")
+  .description("GET /v1/jobs/datasource/{id}")
+  .action(async (datasourceId: string, opts: Record<string, unknown>) => {
+    const { runKbJobsByDatasource } = await import("./kb/commands.js");
+    await runKbJobsByDatasource(datasourceId, kbCtx(opts));
+  });
+
+const kbIngestCmd = kbCmd.command("ingest").description("Queue ingestion (requires ingest permission)");
+
+kbIngestCmd
+  .command("url")
+  .description("POST /v1/ingest/webloader/url")
+  .requiredOption("--url <url>", "URL to ingest")
+  .option("--description <text>", "Datasource description")
+  .option("--owner-team-slug <slug>", "Owning team for RBAC")
+  .action(async (opts: Record<string, unknown>) => {
+    const { runKbIngestUrl } = await import("./kb/commands.js");
+    await runKbIngestUrl(String(opts.url), {
+      ...kbCtx(opts),
+      description: opts.description as string | undefined,
+      ownerTeamSlug: opts.ownerTeamSlug as string | undefined,
+    });
+  });
+
+kbIngestCmd
+  .command("file <paths...>")
+  .description("POST /v1/ingest/local-file (markdown, text, pdf)")
+  .option("--description <text>", "Datasource description")
+  .option("--owner-team-slug <slug>", "Owning team for RBAC")
+  .option("--chunk-size <n>", "Chunk size", "10000")
+  .option("--chunk-overlap <n>", "Chunk overlap", "2000")
+  .action(async (paths: string[], opts: Record<string, unknown>) => {
+    const { runKbIngestFile } = await import("./kb/commands.js");
+    await runKbIngestFile(paths, {
+      ...kbCtx(opts),
+      description: opts.description as string | undefined,
+      ownerTeamSlug: opts.ownerTeamSlug as string | undefined,
+      chunkSize: Number(opts.chunkSize),
+      chunkOverlap: Number(opts.chunkOverlap),
+    });
+  });
+
+void kbCmd;
+
+// ---------------------------------------------------------------------------
 // caipe memory
 // ---------------------------------------------------------------------------
 program

--- a/src/kb/auth.ts
+++ b/src/kb/auth.ts
@@ -1,0 +1,22 @@
+/**
+ * Resolve Bearer tokens for KB API calls (scriptable + interactive).
+ */
+
+import { getValidToken } from "../auth/tokens.js";
+import { resolveHeadlessCredentials } from "../headless/auth.js";
+
+export interface KbAuthOptions {
+  token?: string;
+  authUrl?: string;
+}
+
+export async function resolveKbAccessToken(options: KbAuthOptions): Promise<string> {
+  const headless = await resolveHeadlessCredentials(options.token, options.authUrl);
+  if (headless) {
+    return headless.accessToken;
+  }
+  if (!options.authUrl) {
+    throw new Error("authUrl is required when resolving interactive credentials");
+  }
+  return getValidToken(options.authUrl);
+}

--- a/src/kb/client.ts
+++ b/src/kb/client.ts
@@ -3,7 +3,7 @@
  */
 
 import { getAuthUrl, getKbUrl } from "../platform/config.js";
-import { resolveKbAccessToken, type KbAuthOptions } from "./auth.js";
+import { type KbAuthOptions, resolveKbAccessToken } from "./auth.js";
 
 export interface KbRequestOptions extends KbAuthOptions {
   kbUrl?: string;
@@ -11,7 +11,7 @@ export interface KbRequestOptions extends KbAuthOptions {
   method?: string;
   body?: unknown;
   /** Raw body (e.g. multipart FormData) — skips JSON Content-Type */
-  rawBody?: BodyInit;
+  rawBody?: NonNullable<RequestInit["body"]>;
   searchParams?: Record<string, string | number | undefined>;
 }
 
@@ -63,7 +63,7 @@ export async function kbRequest<T = unknown>(
     headers["X-Tenant-Id"] = options.tenantId.trim();
   }
 
-  let body: BodyInit | undefined;
+  let body: NonNullable<RequestInit["body"]> | undefined;
   if (options.rawBody !== undefined) {
     body = options.rawBody;
   } else if (options.body !== undefined) {

--- a/src/kb/client.ts
+++ b/src/kb/client.ts
@@ -1,0 +1,103 @@
+/**
+ * HTTP client for the CAIPE Knowledge Base RAG REST API.
+ */
+
+import { getAuthUrl, getKbUrl } from "../platform/config.js";
+import { resolveKbAccessToken, type KbAuthOptions } from "./auth.js";
+
+export interface KbRequestOptions extends KbAuthOptions {
+  kbUrl?: string;
+  tenantId?: string;
+  method?: string;
+  body?: unknown;
+  /** Raw body (e.g. multipart FormData) — skips JSON Content-Type */
+  rawBody?: BodyInit;
+  searchParams?: Record<string, string | number | undefined>;
+}
+
+export class KbApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly body?: unknown,
+  ) {
+    super(message);
+    this.name = "KbApiError";
+  }
+}
+
+function joinKbPath(base: string, path: string): string {
+  const b = base.replace(/\/+$/, "");
+  const p = path.startsWith("/") ? path : `/${path}`;
+  return `${b}${p}`;
+}
+
+/** FastAPI `{chunk_id:path}` — preserve slashes inside chunk ids */
+export function chunkContentApiPath(chunkId: string): string {
+  const id = chunkId.replace(/^\/+|\/+$/g, "");
+  return `/v1/chunk/${id}/content`;
+}
+
+export async function kbRequest<T = unknown>(
+  path: string,
+  options: KbRequestOptions = {},
+): Promise<T> {
+  const base = getKbUrl(options.kbUrl);
+  const authUrl = getAuthUrl(options.authUrl);
+  const token = await resolveKbAccessToken({ ...options, authUrl });
+
+  const url = new URL(joinKbPath(base, path));
+  if (options.searchParams) {
+    for (const [key, value] of Object.entries(options.searchParams)) {
+      if (value !== undefined && value !== "") {
+        url.searchParams.set(key, String(value));
+      }
+    }
+  }
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/json",
+  };
+  if (options.tenantId && options.tenantId.trim() !== "") {
+    headers["X-Tenant-Id"] = options.tenantId.trim();
+  }
+
+  let body: BodyInit | undefined;
+  if (options.rawBody !== undefined) {
+    body = options.rawBody;
+  } else if (options.body !== undefined) {
+    headers["Content-Type"] = "application/json";
+    body = JSON.stringify(options.body);
+  }
+
+  const res = await fetch(url.toString(), {
+    method: options.method ?? (body !== undefined ? "POST" : "GET"),
+    headers,
+    body,
+  });
+
+  const text = await res.text();
+  let parsed: unknown = text;
+  if (text !== "") {
+    try {
+      parsed = JSON.parse(text) as unknown;
+    } catch {
+      parsed = text;
+    }
+  } else {
+    parsed = null;
+  }
+
+  if (!res.ok) {
+    const detail =
+      typeof parsed === "object" && parsed !== null && "detail" in parsed
+        ? String((parsed as { detail: unknown }).detail)
+        : typeof parsed === "string"
+          ? parsed
+          : res.statusText;
+    throw new KbApiError(detail || `HTTP ${res.status}`, res.status, parsed);
+  }
+
+  return parsed as T;
+}

--- a/src/kb/commands.ts
+++ b/src/kb/commands.ts
@@ -1,0 +1,161 @@
+/**
+ * Non-interactive Knowledge Base commands (JSON output).
+ */
+
+import { readFileSync } from "node:fs";
+import { basename } from "node:path";
+import { getAuthUrl } from "../platform/config.js";
+import { chunkContentApiPath, kbRequest } from "./client.js";
+import { writeKbError, writeKbJson } from "./output.js";
+
+export interface KbCommandContext {
+  authUrl?: string;
+  kbUrl?: string;
+  token?: string;
+  tenantId?: string;
+}
+
+function ctx(opts: KbCommandContext): KbCommandContext {
+  return {
+    authUrl: getAuthUrl(opts.authUrl),
+    kbUrl: opts.kbUrl,
+    token: opts.token,
+    tenantId: opts.tenantId,
+  };
+}
+
+export async function runKbUserInfo(opts: KbCommandContext): Promise<void> {
+  try {
+    const data = await kbRequest("/v1/user/info", ctx(opts));
+    writeKbJson(data);
+  } catch (e) {
+    writeKbError(e);
+  }
+}
+
+export async function runKbDatasourcesList(opts: KbCommandContext): Promise<void> {
+  try {
+    const data = await kbRequest("/v1/datasources", ctx(opts));
+    writeKbJson(data);
+  } catch (e) {
+    writeKbError(e);
+  }
+}
+
+export async function runKbDocumentsList(
+  datasourceId: string,
+  opts: KbCommandContext & { offset?: number; limit?: number },
+): Promise<void> {
+  try {
+    const data = await kbRequest(`/v1/datasource/${encodeURIComponent(datasourceId)}/documents`, {
+      ...ctx(opts),
+      searchParams: { offset: opts.offset ?? 0, limit: opts.limit ?? 100 },
+    });
+    writeKbJson(data);
+  } catch (e) {
+    writeKbError(e);
+  }
+}
+
+export async function runKbChunkGet(chunkId: string, opts: KbCommandContext): Promise<void> {
+  try {
+    const data = await kbRequest(chunkContentApiPath(chunkId), ctx(opts));
+    writeKbJson(data);
+  } catch (e) {
+    writeKbError(e);
+  }
+}
+
+export async function runKbQuery(
+  query: string,
+  opts: KbCommandContext & { limit?: number },
+): Promise<void> {
+  try {
+    const data = await kbRequest("/v1/query", {
+      ...ctx(opts),
+      method: "POST",
+      body: {
+        query,
+        limit: opts.limit ?? 10,
+      },
+    });
+    writeKbJson(data);
+  } catch (e) {
+    writeKbError(e);
+  }
+}
+
+export async function runKbJobGet(jobId: string, opts: KbCommandContext): Promise<void> {
+  try {
+    const data = await kbRequest(`/v1/job/${encodeURIComponent(jobId)}`, ctx(opts));
+    writeKbJson(data);
+  } catch (e) {
+    writeKbError(e);
+  }
+}
+
+export async function runKbJobsByDatasource(
+  datasourceId: string,
+  opts: KbCommandContext,
+): Promise<void> {
+  try {
+    const data = await kbRequest(`/v1/jobs/datasource/${encodeURIComponent(datasourceId)}`, ctx(opts));
+    writeKbJson(data);
+  } catch (e) {
+    writeKbError(e);
+  }
+}
+
+export async function runKbIngestUrl(
+  url: string,
+  opts: KbCommandContext & { description?: string; ownerTeamSlug?: string },
+): Promise<void> {
+  try {
+    const data = await kbRequest("/v1/ingest/webloader/url", {
+      ...ctx(opts),
+      method: "POST",
+      body: {
+        url,
+        description: opts.description ?? "",
+        owner_team_slug: opts.ownerTeamSlug,
+      },
+    });
+    writeKbJson(data);
+  } catch (e) {
+    writeKbError(e);
+  }
+}
+
+export async function runKbIngestFile(
+  paths: string[],
+  opts: KbCommandContext & {
+    description?: string;
+    ownerTeamSlug?: string;
+    chunkSize?: number;
+    chunkOverlap?: number;
+  },
+): Promise<void> {
+  try {
+    const form = new FormData();
+    for (const p of paths) {
+      const buf = readFileSync(p);
+      const name = basename(p);
+      form.append("file", new Blob([buf]), name);
+    }
+    if (opts.description) form.append("description", opts.description);
+    if (opts.ownerTeamSlug) form.append("owner_team_slug", opts.ownerTeamSlug);
+    if (opts.chunkSize !== undefined) form.append("chunk_size", String(opts.chunkSize));
+    if (opts.chunkOverlap !== undefined) form.append("chunk_overlap", String(opts.chunkOverlap));
+
+    const data = await kbRequest("/v1/ingest/local-file", {
+      ...ctx(opts),
+      method: "POST",
+      rawBody: form,
+    });
+    writeKbJson(data);
+  } catch (e) {
+    writeKbError(e);
+  }
+}
+
+export type KbCommandContextInput = KbCommandContext;

--- a/src/kb/commands.ts
+++ b/src/kb/commands.ts
@@ -99,7 +99,10 @@ export async function runKbJobsByDatasource(
   opts: KbCommandContext,
 ): Promise<void> {
   try {
-    const data = await kbRequest(`/v1/jobs/datasource/${encodeURIComponent(datasourceId)}`, ctx(opts));
+    const data = await kbRequest(
+      `/v1/jobs/datasource/${encodeURIComponent(datasourceId)}`,
+      ctx(opts),
+    );
     writeKbJson(data);
   } catch (e) {
     writeKbError(e);

--- a/src/kb/output.ts
+++ b/src/kb/output.ts
@@ -2,15 +2,16 @@
  * KB commands always emit JSON (AWS CLI style).
  */
 
+import { KbApiError } from "./client.js";
+
 export function writeKbJson(data: unknown): void {
   process.stdout.write(`${JSON.stringify(data, null, 2)}\n`);
 }
 
 export function writeKbError(err: unknown): never {
-  if (err && typeof err === "object" && "name" in err && err.name === "KbApiError") {
-    const e = err as { message: string; status: number; body?: unknown };
+  if (err instanceof KbApiError) {
     process.stderr.write(
-      `${JSON.stringify({ error: e.message, status: e.status, body: e.body ?? null }, null, 2)}\n`,
+      `${JSON.stringify({ error: err.message, status: err.status, body: err.body ?? null }, null, 2)}\n`,
     );
     process.exit(1);
   }

--- a/src/kb/output.ts
+++ b/src/kb/output.ts
@@ -1,0 +1,20 @@
+/**
+ * KB commands always emit JSON (AWS CLI style).
+ */
+
+export function writeKbJson(data: unknown): void {
+  process.stdout.write(`${JSON.stringify(data, null, 2)}\n`);
+}
+
+export function writeKbError(err: unknown): never {
+  if (err && typeof err === "object" && "name" in err && err.name === "KbApiError") {
+    const e = err as { message: string; status: number; body?: unknown };
+    process.stderr.write(
+      `${JSON.stringify({ error: e.message, status: e.status, body: e.body ?? null }, null, 2)}\n`,
+    );
+    process.exit(1);
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`${JSON.stringify({ error: message }, null, 2)}\n`);
+  process.exit(1);
+}

--- a/src/platform/config.ts
+++ b/src/platform/config.ts
@@ -44,6 +44,20 @@ export interface Settings {
     /** Default dynamic agent id when --agent is omitted or `default` (CAIPE_DEFAULT_AGENT overrides) */
     default?: string;
   };
+  kb?: {
+    /** Knowledge Base RAG REST API base URL (CAIPE_KB_URL overrides) */
+    url?: string;
+  };
+}
+
+export class KbNotConfigured extends Error {
+  constructor() {
+    super(
+      "No Knowledge Base API URL configured. Run `caipe config set kb.url https://your-kb-api.example.com` " +
+        "or set CAIPE_KB_URL.",
+    );
+    this.name = "KbNotConfigured";
+  }
 }
 
 export class ServerNotConfigured extends Error {
@@ -160,6 +174,7 @@ export function readSettings(): Settings {
       auth: { ...DEFAULT_SETTINGS.auth, ...saved.auth },
       setup: saved.setup,
       agent: saved.agent,
+      kb: saved.kb,
     };
   } catch {
     return { ...DEFAULT_SETTINGS };
@@ -264,6 +279,28 @@ export function getConfiguredDefaultAgent(): string | undefined {
   const fromSettings = readSettings().agent?.default;
   if (fromSettings && fromSettings.trim() !== "") return fromSettings.trim();
   return undefined;
+}
+
+/**
+ * Resolve the Knowledge Base RAG REST API base URL.
+ *
+ * Priority: flagOverride → CAIPE_KB_URL → settings.kb.url
+ *
+ * Throws KbNotConfigured when nothing is configured.
+ */
+export function getKbUrl(flagOverride?: string): string {
+  if (flagOverride && flagOverride.trim() !== "") {
+    return normalizeUrl(flagOverride);
+  }
+  const env = process.env.CAIPE_KB_URL;
+  if (env && env.trim() !== "") {
+    return normalizeUrl(env);
+  }
+  const fromSettings = readSettings().kb?.url;
+  if (fromSettings && fromSettings.trim() !== "") {
+    return normalizeUrl(fromSettings);
+  }
+  throw new KbNotConfigured();
 }
 
 /** Endpoints derived from the caipe-ui (auth) URL. */

--- a/src/platform/configcmd.ts
+++ b/src/platform/configcmd.ts
@@ -21,7 +21,8 @@ type SupportedKey =
   | "auth.apiKey"
   | "auth.credential-storage"
   | "auth.idp-hint"
-  | "agent.default";
+  | "agent.default"
+  | "kb.url";
 
 const SUPPORTED_KEYS: SupportedKey[] = [
   "auth.url",
@@ -30,6 +31,7 @@ const SUPPORTED_KEYS: SupportedKey[] = [
   "auth.credential-storage",
   "auth.idp-hint",
   "agent.default",
+  "kb.url",
 ];
 
 const CREDENTIAL_STORAGE_VALUES = ["encrypted-file", "keychain"] as const;
@@ -135,6 +137,15 @@ export async function runConfigSet(key: string, value: string): Promise<void> {
     process.stdout.write(`Set agent.default = ${id}\n`);
     return;
   }
+
+  if (key === "kb.url") {
+    const url = normalizeConfigUrl(value, "kb.url");
+    const settings = readSettings();
+    settings.kb = { ...settings.kb, url };
+    writeSettings(settings);
+    process.stdout.write(`Set kb.url = ${url}\n`);
+    return;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -185,6 +196,14 @@ export async function runConfigGet(key: string, opts: { json?: boolean }): Promi
     } else {
       value = settings.agent?.default;
     }
+  } else if (key === "kb.url") {
+    const envVal = process.env.CAIPE_KB_URL;
+    if (envVal) {
+      value = envVal;
+      source = "CAIPE_KB_URL env var";
+    } else {
+      value = settings.kb?.url;
+    }
   }
 
   if (opts.json) {
@@ -230,6 +249,8 @@ export async function runConfigUnset(key: string): Promise<void> {
     settings.auth.idpHint = undefined;
   } else if (key === "agent.default" && settings.agent) {
     settings.agent.default = undefined;
+  } else if (key === "kb.url" && settings.kb) {
+    settings.kb.url = undefined;
   }
 
   writeSettings(settings);

--- a/tests/kb.test.ts
+++ b/tests/kb.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { chunkContentApiPath } from "../src/kb/client.js";
+
+describe("chunkContentApiPath", () => {
+  it("builds path for simple chunk ids", () => {
+    expect(chunkContentApiPath("abc123")).toBe("/v1/chunk/abc123/content");
+  });
+
+  it("preserves slashes for path-style chunk ids", () => {
+    expect(chunkContentApiPath("tenant/ds/doc/0")).toBe("/v1/chunk/tenant/ds/doc/0/content");
+  });
+
+  it("strips leading and trailing slashes on the id", () => {
+    expect(chunkContentApiPath("/foo/bar/")).toBe("/v1/chunk/foo/bar/content");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds **`caipe kb`** — AWS CLI-style commands that always emit JSON for scripts/CI: user/RBAC info, datasources, documents, chunk content, semantic query, ingest (URL/file), and job status.
- Config: **`kb.url`** / **`CAIPE_KB_URL`**, plus shared flags `--kb-url`, `--token`, `--tenant-id` on the `kb` command group.
- Reuses existing headless auth (`CAIPE_TOKEN`, client credentials) and interactive OAuth session tokens for `Authorization: Bearer`.

## Grid / prod usage

Point at the UI BFF RAG proxy (requires [cnoe-io/ai-platform-engineering#2297](https://github.com/cnoe-io/ai-platform-engineering/pull/2297) for Bearer support):

```bash
caipe config set kb.url https://grid.outshift.io/api/rag
caipe auth login
caipe kb user info
caipe kb query --query "..."
```

Until the upstream BFF change ships, use port-forward to `rag-server:9446` or set `kb.url` to a reachable RAG base URL.

## Test plan

- [x] `bun test tests/kb.test.ts`
- [ ] `caipe kb --help` and subcommand help
- [ ] Against Grid (post-2297): `caipe kb user info`, `caipe kb datasources list`
- [ ] Port-forward smoke: query + chunk get


Made with [Cursor](https://cursor.com)