### PR TITLE
fix(types): repair type check on main

### DIFF
--- a/src/agents/AgentPicker.tsx
+++ b/src/agents/AgentPicker.tsx
@@ -57,9 +57,7 @@ export function AgentPicker({
           {filter ? ` · filter: "${filter}"` : " · type to filter"}
         </Text>
       </Box>
-      {start > 0 ? (
-        <Text dimColor>{`  ↑ ${start} more above`}</Text>
-      ) : null}
+      {start > 0 ? <Text dimColor>{`  ↑ ${start} more above`}</Text> : null}
       {slice.map((agent, i) => {
         const idx = start + i;
         const selected = idx === safeIndex;
@@ -76,16 +74,29 @@ export function AgentPicker({
 
         return (
           <Box key={agent.name} flexDirection="column" marginY={selected ? 0 : 0}>
-            <Box backgroundColor={rowBg} flexDirection="column" paddingX={selected ? 1 : 0}>
+            {/* ink 5 has no Box-level background; the row tint lives on the Text nodes. */}
+            <Box flexDirection="column" paddingX={selected ? 1 : 0}>
               <Box>
-                <Text bold={selected} color={titleColor} dimColor={titleDim && !rich}>
+                <Text
+                  backgroundColor={rowBg}
+                  bold={selected}
+                  color={titleColor}
+                  dimColor={titleDim && !rich}
+                >
                   {selected ? "▶ " : "  "}
                 </Text>
-                <Text bold={selected} color={titleColor} dimColor={titleDim && !rich} wrap="truncate">
+                <Text
+                  backgroundColor={rowBg}
+                  bold={selected}
+                  color={titleColor}
+                  dimColor={titleDim && !rich}
+                  wrap="truncate"
+                >
                   {title}
                 </Text>
                 {inSession ? (
                   <Text
+                    backgroundColor={rowBg}
                     bold={selected}
                     color={selected && rich ? "white" : undefined}
                     dimColor={!selected || !rich}
@@ -98,6 +109,7 @@ export function AgentPicker({
                 <>
                   <Box paddingLeft={2}>
                     <Text
+                      backgroundColor={rowBg}
                       color={rich ? "white" : "cyan"}
                       dimColor={!rich}
                       wrap="truncate"
@@ -107,7 +119,12 @@ export function AgentPicker({
                   </Box>
                   {descLine ? (
                     <Box paddingLeft={2}>
-                      <Text color={rich ? "white" : undefined} dimColor={!rich} wrap="wrap">
+                      <Text
+                        backgroundColor={rowBg}
+                        color={rich ? "white" : undefined}
+                        dimColor={!rich}
+                        wrap="wrap"
+                      >
                         {descLine}
                       </Text>
                     </Box>
@@ -124,9 +141,7 @@ export function AgentPicker({
           </Box>
         );
       })}
-      {end < agents.length ? (
-        <Text dimColor>{`  ↓ ${agents.length - end} more below`}</Text>
-      ) : null}
+      {end < agents.length ? <Text dimColor>{`  ↓ ${agents.length - end} more below`}</Text> : null}
       <Box marginTop={0}>
         <Text color="cyan" bold>
           {`${safeIndex + 1}/${agents.length}`}
@@ -135,9 +150,7 @@ export function AgentPicker({
         <Text bold color="white">
           {selectedAgent ? agentTitle(selectedAgent) : ""}
         </Text>
-        <Text dimColor>
-          {` · Enter switch · ${agents.length} total · or /agents <id>`}
-        </Text>
+        <Text dimColor>{` · Enter switch · ${agents.length} total · or /agents <id>`}</Text>
       </Box>
     </Box>
   );

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -138,7 +138,11 @@ export function pickSessionAgent(
     );
   }
 
+  // agents is non-empty (guarded above), so agents[0] is always defined.
   const pick = agents.find((a) => a.available) ?? agents[0];
+  if (!pick) {
+    throw new Error("No agents returned for your account. Run `caipe agents list`.");
+  }
   return pick;
 }
 

--- a/src/chat/markdown-stream.ts
+++ b/src/chat/markdown-stream.ts
@@ -28,7 +28,7 @@ export function partitionMarkdown(source: string): MarkdownPartition {
   for (const line of lines) {
     const fence = line.match(/^(`{3,}|~{3,})/);
     if (fence) {
-      const marker = fence[1];
+      const marker = fence[1] ?? "";
       if (!inFence) {
         inFence = true;
         fenceMarker = marker;

--- a/src/platform/display.tsx
+++ b/src/platform/display.tsx
@@ -131,8 +131,8 @@ export function StreamingSpinner({
   );
 }
 
-import { formatToolTreeLabel } from "./terminal/tool-label.js";
 import { animatedWaitEnabled } from "./terminal/repl-ui.js";
+import { formatToolTreeLabel } from "./terminal/tool-label.js";
 
 const SHELL_TOOL_NAMES = new Set([
   "bash",
@@ -165,8 +165,9 @@ export interface UserMessageBarProps {
 export function UserMessageBar({ text, width }: UserMessageBarProps): React.ReactElement {
   return (
     <Box width={width} marginBottom={1}>
-      <Box width={width} backgroundColor={NO_COLOR ? undefined : "gray"} paddingX={1}>
-        <Text wrap="wrap">
+      {/* ink 5 has no Box-level background; the band tint lives on the Text nodes. */}
+      <Box width={width} paddingX={1}>
+        <Text backgroundColor={NO_COLOR ? undefined : "gray"} wrap="wrap">
           <Text bold={!NO_COLOR}>{"> "}</Text>
           <Text>{text}</Text>
         </Text>
@@ -242,8 +243,7 @@ export function ToolActivityPanel({
         ? `Ran ${runs.length + omittedCount} ${noun} · ${elapsed}s`
         : `Ran ${runs.length} ${noun} · ${elapsed}s`;
 
-  const treeCap =
-    maxTreeRows === Number.POSITIVE_INFINITY ? runs.length : Math.max(0, maxTreeRows);
+  const treeCap = maxTreeRows === Number.POSITIVE_INFINITY ? runs.length : Math.max(0, maxTreeRows);
   const treeRuns = treeCap >= runs.length ? runs : runs.slice(-treeCap);
 
   return (
@@ -256,13 +256,18 @@ export function ToolActivityPanel({
         ) : (
           <Text dimColor>● </Text>
         )}
-        <Text color={phase === "running" && !NO_COLOR ? "yellow" : undefined} dimColor={phase === "done"}>
+        <Text
+          color={phase === "running" && !NO_COLOR ? "yellow" : undefined}
+          dimColor={phase === "done"}
+        >
           {summary}
         </Text>
       </Box>
       {omittedCount > 0 ? (
         <Box paddingX={1} marginLeft={2}>
-          <Text dimColor>… {omittedCount} earlier {omittedCount === 1 ? "tool" : "tools"}</Text>
+          <Text dimColor>
+            … {omittedCount} earlier {omittedCount === 1 ? "tool" : "tools"}
+          </Text>
         </Box>
       ) : null}
       {treeRuns.map((run, idx) => {
@@ -281,8 +286,7 @@ export function ToolActivityPanel({
                 </>
               ) : (
                 <>
-                  ${" "}
-                  <Text color={NO_COLOR ? undefined : "cyan"}>{label}</Text>
+                  $ <Text color={NO_COLOR ? undefined : "cyan"}>{label}</Text>
                 </>
               )}
             </Text>
@@ -333,8 +337,7 @@ export function StreamWaitLine({
     return () => clearInterval(id);
   }, [frames.length]);
 
-  const tokenSuffix =
-    tokenCount !== undefined && tokenCount > 0 ? ` · ↓ ${tokenCount} tokens` : "";
+  const tokenSuffix = tokenCount !== undefined && tokenCount > 0 ? ` · ↓ ${tokenCount} tokens` : "";
 
   return (
     <Box>

--- a/src/platform/terminal/ink-diff.tsx
+++ b/src/platform/terminal/ink-diff.tsx
@@ -3,7 +3,8 @@
  */
 
 import { Box, Text } from "ink";
-import React, { useMemo } from "react";
+import type React from "react";
+import { useMemo } from "react";
 
 import { isRichTerminalEnabled } from "./capabilities.js";
 
@@ -78,11 +79,7 @@ export function InkDiffBlock({ text, width }: InkDiffBlockProps): React.ReactEle
     <Box flexDirection="column" width={width} marginY={0}>
       {lines.map((row, index) => {
         const bg =
-          rich && row.kind === "add"
-            ? "green"
-            : rich && row.kind === "del"
-              ? "red"
-              : undefined;
+          rich && row.kind === "add" ? "green" : rich && row.kind === "del" ? "red" : undefined;
         const fg =
           row.kind === "add"
             ? rich
@@ -95,12 +92,18 @@ export function InkDiffBlock({ text, width }: InkDiffBlockProps): React.ReactEle
               : undefined;
 
         return (
-          <Box key={index} backgroundColor={bg} flexDirection="row">
-            <Text dimColor={row.kind === "meta"}>
+          // ink 5 has no Box-level background; the row tint lives on the Text nodes.
+          <Box key={index} flexDirection="row">
+            <Text backgroundColor={bg} dimColor={row.kind === "meta"}>
               {gutterCell(row.oldNum)}
               {row.kind === "add" || row.kind === "context" ? gutterCell(row.newNum) : "    "}
             </Text>
-            <Text color={fg} dimColor={row.kind === "meta"} wrap="truncate-end">
+            <Text
+              backgroundColor={bg}
+              color={fg}
+              dimColor={row.kind === "meta"}
+              wrap="truncate-end"
+            >
               {row.display}
             </Text>
           </Box>

--- a/src/platform/terminal/marked-list-fix.ts
+++ b/src/platform/terminal/marked-list-fix.ts
@@ -3,14 +3,10 @@
  * inline tokens live under a nested `text` token. Override `list` only.
  */
 
-import type { MarkedExtension, Parser } from "marked";
+import type { MarkedExtension, Parser, Token, Tokens } from "marked";
 
-type InlineCapable = { type: string; tokens?: InlineCapable[] };
-type ListItemToken = { loose?: boolean; tokens?: InlineCapable[] };
-type ListToken = { ordered?: boolean; start?: number | string; items: ListItemToken[] };
-
-function listItemInlineText(parser: Parser, item: ListItemToken): string {
-  const parts = item.tokens ?? [];
+function listItemInlineText(parser: Parser, item: Tokens.ListItem): string {
+  const parts: Token[] = item.tokens ?? [];
   if (parts.length === 0) return "";
 
   if (item.loose) {
@@ -32,14 +28,12 @@ function listItemInlineText(parser: Parser, item: ListItemToken): string {
 
 export function markedListInlineExtension(): MarkedExtension {
   return {
-    name: "caipe-list-inline",
     renderer: {
-      list(token) {
-        const listToken = token as ListToken;
-        let index = listToken.start ? Number(listToken.start) : 1;
-        const lines = listToken.items.map((item) => {
+      list(token: Tokens.List) {
+        let index = token.start ? Number(token.start) : 1;
+        const lines = token.items.map((item) => {
           const content = listItemInlineText(this.parser, item);
-          const prefix = listToken.ordered ? `${index++}. ` : "• ";
+          const prefix = token.ordered ? `${index++}. ` : "• ";
           return prefix + content;
         });
         return `${lines.join("\n")}\n\n`;

--- a/src/platform/terminal/marked-table-width.ts
+++ b/src/platform/terminal/marked-table-width.ts
@@ -2,18 +2,11 @@
  * GFM tables sized to the Ink content column (marked-terminal ignores width for tables).
  */
 
-import Table from "cli-table3";
 import chalk from "chalk";
-import type { MarkedExtension, Parser } from "marked";
+import Table from "cli-table3";
+import type { MarkedExtension, Parser, Tokens } from "marked";
 
-type TableCellToken = { tokens: { type: string; raw?: string; text?: string; tokens?: unknown[] }[] };
-
-type TableToken = {
-  header: TableCellToken[];
-  rows: TableCellToken[][];
-};
-
-function inlineCell(parser: Parser, cell: TableCellToken): string {
+function inlineCell(parser: Parser, cell: Tokens.TableCell): string {
   return parser.parseInline(cell.tokens).trim();
 }
 
@@ -22,7 +15,7 @@ export function tableBorderSlack(columnCount: number): number {
   return columnCount + 3;
 }
 
-function normalizeHeader(cell: TableCellToken, parser: Parser): string {
+function normalizeHeader(cell: Tokens.TableCell, parser: Parser): string {
   return inlineCell(parser, cell).toLowerCase().replace(/\s+/g, " ").trim();
 }
 
@@ -64,7 +57,7 @@ export function layoutTableColWidths(
     }
 
     const hasLinkCol = h.some((c) => c === "link" || c.includes("url"));
-    if (n === 3 && (h[0] === "#" || h[0].startsWith("#")) && hasLinkCol) {
+    if (n === 3 && h[0]?.startsWith("#") && hasLinkCol) {
       const num = 5;
       const title = Math.min(22, Math.max(10, Math.floor(inner * 0.22)));
       const link = inner - num - title;
@@ -87,15 +80,13 @@ export function layoutTableColWidths(
 export function markedTableWidthExtension(contentWidth: number): MarkedExtension {
   const colBudget = Math.max(24, contentWidth);
   return {
-    name: "caipe-table-width",
     renderer: {
-      table(token) {
-        const tableToken = token as TableToken;
-        const cols = tableToken.header.length;
+      table(token: Tokens.Table) {
+        const cols = token.header.length;
         if (cols === 0) return "";
-        const headers = tableToken.header.map((cell) => normalizeHeader(cell, this.parser));
+        const headers = token.header.map((cell) => normalizeHeader(cell, this.parser));
         const colWidths = layoutTableColWidths(cols, colBudget, headers);
-        const head = tableToken.header.map((cell) => inlineCell(this.parser, cell));
+        const head = token.header.map((cell) => inlineCell(this.parser, cell));
         const table = new Table({
           head,
           colWidths,
@@ -103,7 +94,7 @@ export function markedTableWidthExtension(contentWidth: number): MarkedExtension
           wrapOnWordBoundary: true,
           style: { head: ["cyan", "bold"], border: ["gray"] },
         });
-        for (const row of tableToken.rows) {
+        for (const row of token.rows) {
           table.push(row.map((cell) => inlineCell(this.parser, cell)));
         }
         return `${chalk.reset(table.toString())}\n\n`;

--- a/src/types/marked-terminal.d.ts
+++ b/src/types/marked-terminal.d.ts
@@ -1,0 +1,23 @@
+/**
+ * marked-terminal v7 ships no type declarations. Minimal ambient types for the
+ * subset used by {@link ../platform/terminal/ansi-markdown.ts}.
+ */
+declare module "marked-terminal" {
+  import type { MarkedExtension } from "marked";
+
+  export interface MarkedTerminalOptions {
+    width?: number;
+    reflowText?: boolean;
+    showSectionPrefix?: boolean;
+    tab?: number;
+    unescape?: boolean;
+    emoji?: boolean;
+    tableOptions?: Record<string, unknown>;
+    [style: string]: unknown;
+  }
+
+  export function markedTerminal(
+    options?: MarkedTerminalOptions,
+    highlightOptions?: Record<string, unknown>,
+  ): MarkedExtension;
+}

--- a/tests/marked-table-width.test.ts
+++ b/tests/marked-table-width.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
+import { renderMarkdownToAnsi } from "../src/platform/terminal/ansi-markdown.js";
 import {
   ansiFitsWidth,
   layoutTableColWidths,
   maxVisibleLineWidth,
   tableBorderSlack,
 } from "../src/platform/terminal/marked-table-width.js";
-import { renderMarkdownToAnsi } from "../src/platform/terminal/ansi-markdown.js";
 
 describe("tableBorderSlack", () => {
   it("accounts for cli-table3 borders per column count", () => {
@@ -37,7 +37,7 @@ describe("layoutTableColWidths", () => {
     const cols = layoutTableColWidths(3, 72, headers);
     expect(cols[0]).toBe(5);
     expect(cols[2]).toBeGreaterThanOrEqual(16);
-    expect(cols[2]).toBeGreaterThan(cols[1]);
+    expect(cols[2]).toBeGreaterThan(Number(cols[1]));
   });
 
   it("splits two-column tables path vs description", () => {


### PR DESCRIPTION
`bun tsc --noEmit` has been failing on `main`, which blocks the CI pipeline at its first step for every open PR (including #36). None of these errors are new — they accumulated across recent merges.

## What was broken

- **`backgroundColor` on Ink `Box`** (`AgentPicker.tsx`, `display.tsx`, `ink-diff.tsx`) — ink 5 exposes `backgroundColor` on `Text`, not `Box`. These were both a type error *and* a silent runtime no-op, so the intended row/band tints never rendered. Moved onto the `Text` nodes, which restores the intent.
- **marked v15 renderer extensions** (`marked-list-fix.ts`, `marked-table-width.ts`) — replaced hand-rolled structural token types with marked's own `Tokens.List` / `Tokens.Table` / `Tokens.TableCell`, and dropped the top-level `name` key, which is not part of `MarkedExtension`.
- **`marked-terminal` v7 ships no declarations** — added a minimal ambient module for the subset `ansi-markdown.ts` uses.
- **`noUncheckedIndexedAccess`** — `registry.ts`, `markdown-stream.ts`, and the `marked-table-width` test.

## Verification

- `bun tsc --noEmit` → exits 0 (was 17 errors).
- `bun run test` → 182 pass / 19 fail, **identical to clean `main`**. This change is behavior-neutral with respect to the suite.

## Still red after this

CI will now get past the type-check step and fail at lint instead. `bun run lint` reports 99 errors on clean `main` (98 with this branch). The 19 test failures above are also pre-existing. Both are being handled separately — this PR is deliberately scoped to the type check so the diff stays reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
