### PR TITLE
chore: replace internal hostnames with example.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ git clone https://github.com/cnoe-io/caipe-cli.git && cd caipe-cli && bun instal
 # binary: ./dist/caipe  — add to PATH or symlink ~/.local/bin/caipe
 ```
 
-**Point at Grid preview, sign in, chat:**
+**Point at your Grid deployment, sign in, chat:**
 
 ```bash
-caipe config set server.url https://grid.preview.outshift.io
-caipe config set auth.url https://idp.grid.preview.outshift.io/realms/caipe
+caipe config set server.url https://grid.example.com
+caipe config set auth.url https://idp.grid.example.com/realms/caipe
 caipe auth login
 caipe agents list
 caipe chat --agent '<id-from-agents-list>'
@@ -63,7 +63,7 @@ bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/caipe-cli/main/setup
 Preconfigure the server:
 
 ```bash
-CAIPE_SERVER_URL=https://grid.preview.outshift.io \
+CAIPE_SERVER_URL=https://grid.example.com \
   bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/caipe-cli/main/setup-caipe-cli.sh)
 ```
 
@@ -146,13 +146,13 @@ caipe chat
 
 `config set server.url` also sets **`auth.url`** to the same value.
 
-### Grid preview (split API vs IdP)
+### Split API vs IdP
 
-On **`grid.preview.outshift.io`**, the BFF may not expose `/oauth/authorize` yet. Point **API** at Grid and **OAuth** at Keycloak:
+On some deployments the BFF may not expose `/oauth/authorize` yet. Point **API** at Grid and **OAuth** at Keycloak:
 
 ```bash
-caipe config set server.url https://grid.preview.outshift.io
-caipe config set auth.url https://idp.grid.preview.outshift.io/realms/caipe
+caipe config set server.url https://grid.example.com
+caipe config set auth.url https://idp.grid.example.com/realms/caipe
 rm -f ~/.config/caipe/agent-config.json
 caipe auth logout    # if you have stale tokens
 caipe auth login

--- a/tests/auth-claims.test.ts
+++ b/tests/auth-claims.test.ts
@@ -42,10 +42,10 @@ describe("formatClientContextBlock", () => {
   it("derives email from token set", () => {
     const tokens: TokenSet = {
       accessToken: "x",
-      email: "agent-user@grid.outshift.io",
+      email: "agent-user@grid.example.com",
       displayName: "Agent User",
       identity: "uuid-sub",
     };
-    expect(clientUserFromTokenSet(tokens).email).toBe("agent-user@grid.outshift.io");
+    expect(clientUserFromTokenSet(tokens).email).toBe("agent-user@grid.example.com");
   });
 });

--- a/tests/discovery.test.ts
+++ b/tests/discovery.test.ts
@@ -35,17 +35,17 @@ describe("oauthIssuerFromConfig", () => {
 });
 
 describe("heuristicAuthIssuerCandidates", () => {
-  it("maps grid.outshift.io to idp.grid.outshift.io realm", () => {
-    expect(heuristicAuthIssuerCandidates("https://grid.outshift.io")).toEqual([
-      "https://idp.grid.outshift.io/realms/caipe",
-      "https://grid.outshift.io/realms/caipe",
+  it("maps grid.example.com to idp.grid.example.com realm", () => {
+    expect(heuristicAuthIssuerCandidates("https://grid.example.com")).toEqual([
+      "https://idp.grid.example.com/realms/caipe",
+      "https://grid.example.com/realms/caipe",
     ]);
   });
 
   it("maps grid.preview host and respects CAIPE_AUTH_REALM", () => {
     process.env.CAIPE_AUTH_REALM = "myrealm";
-    expect(heuristicAuthIssuerCandidates("https://grid.preview.outshift.io/")).toContain(
-      "https://idp.grid.preview.outshift.io/realms/myrealm",
+    expect(heuristicAuthIssuerCandidates("https://grid.preview.example.com/")).toContain(
+      "https://idp.grid.preview.example.com/realms/myrealm",
     );
     delete process.env.CAIPE_AUTH_REALM;
   });

--- a/tests/terminal.test.ts
+++ b/tests/terminal.test.ts
@@ -59,7 +59,7 @@ describe("OSC 8 links", () => {
   });
 
   it("replaces markdown links", () => {
-    const md = "See [Grid](https://grid.outshift.io) for docs.";
+    const md = "See [Grid](https://grid.example.com) for docs.";
     const out = replaceMarkdownLinksWithOsc8(md);
     expect(out).not.toContain("](https://");
     expect(out).toContain("Grid");


### PR DESCRIPTION
The public repo referenced a specific internal Grid deployment hostname in the README and in three test fixtures. This swaps them for the RFC 2606 reserved example domain.

## Changes

- **README** — the quickstart, the `CAIPE_SERVER_URL` preconfigure snippet, and the split API/IdP section now use `grid.example.com` / `idp.grid.example.com`. Two headings that named the specific environment were reworded to describe the situation instead ("Point at your Grid deployment", "Split API vs IdP").
- **Tests** — `discovery.test.ts`, `auth-claims.test.ts`, and `terminal.test.ts` fixtures. `example.com` was already the convention elsewhere in these files, so this makes them internally consistent.

## Why the discovery tests still hold

`heuristicAuthIssuerCandidates` keys off the `grid.` hostname *prefix*, not the domain, so the renamed fixtures exercise exactly the same code path and assertions.

## Verification

- No `outshift.io` occurrences remain anywhere in the tree.
- The three affected test files: 15/15 pass.
- Full suite unchanged from `main`: 182 pass / 19 fail (those 19 are pre-existing, unrelated).

## Not included

`bin/caipe-path.cjs`, `bin/caipe-installed.cjs`, and `scripts/link-path.sh` hardcode `~/outshift/caipe-cli` as a fallback checkout location. That is a local directory convention rather than the deployment hostname, and changing it could break existing local launcher setups, so it is left for a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
