### PR TITLE
fix(agents): fetch all accessible agent pages

### DIFF
--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -15,10 +15,29 @@ import {
 import type { Agent } from "./types.js";
 
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const PAGE_SIZE = 100;
+const MAX_PAGES = 1_000;
 
 interface CachedAgents {
   agents: Agent[];
   cachedAt: string;
+  serverUrl: string;
+}
+
+interface AgentPickerEntry {
+  id: string;
+  name: string;
+  description: string;
+}
+
+interface AgentPickerResponse {
+  success: boolean;
+  data?: {
+    agents: AgentPickerEntry[];
+    total?: number;
+    page?: number;
+    page_size?: number;
+  };
 }
 
 export interface ValidationResult {
@@ -38,7 +57,7 @@ export async function fetchAgents(
   serverUrl: string,
   getToken: () => Promise<string>,
 ): Promise<Agent[]> {
-  const cached = readCache();
+  const cached = readCache(serverUrl);
   if (cached && Date.now() - Date.parse(cached.cachedAt) < CACHE_TTL_MS) {
     return cached.agents;
   }
@@ -46,21 +65,7 @@ export async function fetchAgents(
   try {
     const ep = authEndpoints(serverUrl);
     const token = await getToken();
-    const res = await fetch(ep.agents, {
-      headers: { Authorization: `Bearer ${token}` },
-      signal: AbortSignal.timeout(10_000),
-    });
-
-    if (!res.ok) {
-      throw new Error(`HTTP ${res.status}`);
-    }
-
-    // Response: { success: true, data: { agents: AgentPickerEntry[], total, page, page_size } }
-    const body = (await res.json()) as {
-      success: boolean;
-      data?: { agents: Array<{ id: string; name: string; description: string }> };
-    };
-    const pickerEntries = body.data?.agents ?? [];
+    const pickerEntries = await fetchAllAgentPages(ep.agents, token);
     const agents: Agent[] = pickerEntries.map((e) => ({
       name: e.id,
       displayName: e.name || e.id,
@@ -70,7 +75,7 @@ export async function fetchAgents(
       available: true,
       domain: "general",
     }));
-    writeCache(agents);
+    writeCache(serverUrl, agents);
     return agents;
   } catch (err) {
     if (cached) {
@@ -81,6 +86,44 @@ export async function fetchAgents(
     }
     throw new Error(`Agents registry unavailable: ${String(err)}`);
   }
+}
+
+async function fetchAllAgentPages(endpoint: string, token: string): Promise<AgentPickerEntry[]> {
+  const entries: AgentPickerEntry[] = [];
+
+  for (let page = 1; page <= MAX_PAGES; page += 1) {
+    const url = new URL(endpoint);
+    url.searchParams.set("page", String(page));
+    url.searchParams.set("page_size", String(PAGE_SIZE));
+
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+
+    const body = (await res.json()) as AgentPickerResponse;
+    const pageEntries = body.data?.agents ?? [];
+    const total = body.data?.total;
+    entries.push(...pageEntries);
+
+    // Older servers may omit pagination metadata. In that case, preserve the
+    // legacy single-page behavior instead of issuing speculative requests.
+    if (typeof total !== "number" || entries.length >= total) {
+      return entries;
+    }
+
+    if (pageEntries.length === 0) {
+      throw new Error(
+        `Agents registry pagination stopped after ${entries.length} of ${total} agents`,
+      );
+    }
+  }
+
+  throw new Error(`Agents registry exceeded ${MAX_PAGES} pages`);
 }
 
 /**
@@ -181,19 +224,31 @@ export function validateProtocol(agent: Agent): ValidationResult {
 // Cache helpers
 // ---------------------------------------------------------------------------
 
-function readCache(): CachedAgents | null {
+function readCache(serverUrl: string): CachedAgents | null {
   const path = agentsCachePath();
   if (!existsSync(path)) return null;
   try {
-    return JSON.parse(readFileSync(path, "utf8")) as CachedAgents;
+    const cached = JSON.parse(readFileSync(path, "utf8")) as Partial<CachedAgents>;
+    if (
+      cached.serverUrl !== serverUrl ||
+      typeof cached.cachedAt !== "string" ||
+      !Array.isArray(cached.agents)
+    ) {
+      return null;
+    }
+    return cached as CachedAgents;
   } catch {
     return null;
   }
 }
 
-function writeCache(agents: Agent[]): void {
+function writeCache(serverUrl: string, agents: Agent[]): void {
   const dir = globalConfigDir();
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-  const cached: CachedAgents = { agents, cachedAt: new Date().toISOString() };
+  const cached: CachedAgents = {
+    agents,
+    cachedAt: new Date().toISOString(),
+    serverUrl,
+  };
   writeFileSync(agentsCachePath(), `${JSON.stringify(cached, null, 2)}\n`, "utf8");
 }

--- a/src/platform/config.ts
+++ b/src/platform/config.ts
@@ -158,26 +158,13 @@ function ensureConfigDir(): void {
   }
 }
 
-const DEFAULT_SETTINGS: Settings = {
-  server: { url: "http://localhost:3000" },
-  auth: { url: "http://localhost:7080/realms/caipe" },
-};
-
 export function readSettings(): Settings {
   const path = settingsJsonPath();
-  if (!existsSync(path)) return { ...DEFAULT_SETTINGS };
+  if (!existsSync(path)) return {};
   try {
-    const saved = JSON.parse(readFileSync(path, "utf8")) as Settings;
-    // Merge: saved values win; fall back to defaults for any missing key
-    return {
-      server: { ...DEFAULT_SETTINGS.server, ...saved.server },
-      auth: { ...DEFAULT_SETTINGS.auth, ...saved.auth },
-      setup: saved.setup,
-      agent: saved.agent,
-      kb: saved.kb,
-    };
+    return JSON.parse(readFileSync(path, "utf8")) as Settings;
   } catch {
-    return { ...DEFAULT_SETTINGS };
+    return {};
   }
 }
 

--- a/src/platform/diff.ts
+++ b/src/platform/diff.ts
@@ -55,7 +55,7 @@ export function renderDiff(oldText: string, newText: string, label: string): str
 
 /** Heuristic: unified diff hunk (---/+++/@@ or many +/- lines). */
 export function isUnifiedDiffText(text: string): boolean {
-  const lines = text.split("\n");
+  const lines = text.replace(/\x1b\[[0-9;]*m/g, "").split("\n");
   const hasHeader =
     lines.some((l) => l.startsWith("--- ")) && lines.some((l) => l.startsWith("+++ "));
   const hasHunk = lines.some((l) => l.startsWith("@@"));

--- a/tests/agents.registry.test.ts
+++ b/tests/agents.registry.test.ts
@@ -1,6 +1,25 @@
-import { describe, expect, it } from "vitest";
-import { pickSessionAgent } from "../src/agents/registry.js";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchAgents, pickSessionAgent } from "../src/agents/registry.js";
 import type { Agent } from "../src/agents/types.js";
+
+let testDir: string;
+
+beforeEach(() => {
+  testDir = join(tmpdir(), `caipe-agents-${process.pid}-${Date.now()}`);
+  mkdirSync(testDir, { recursive: true });
+  process.env.XDG_CONFIG_HOME = testDir;
+});
+
+afterEach(() => {
+  process.env.XDG_CONFIG_HOME = "";
+  vi.unstubAllGlobals();
+  if (existsSync(testDir)) {
+    rmSync(testDir, { recursive: true, force: true });
+  }
+});
 
 const agents: Agent[] = [
   {
@@ -39,5 +58,124 @@ describe("pickSessionAgent", () => {
 
   it("falls back when configured default is not in list", () => {
     expect(pickSessionAgent(agents, "default", "missing-agent").name).toBe("agent-alpha");
+  });
+});
+
+describe("fetchAgents", () => {
+  it("fetches every page of accessible agents", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        Response.json({
+          success: true,
+          data: {
+            agents: [
+              { id: "agent-alpha", name: "Alpha", description: "First page" },
+              { id: "agent-beta", name: "Beta", description: "First page" },
+            ],
+            total: 3,
+            page: 1,
+            page_size: 2,
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        Response.json({
+          success: true,
+          data: {
+            agents: [{ id: "agent-tome", name: "Tome Agent", description: "Second page" }],
+            total: 3,
+            page: 2,
+            page_size: 2,
+          },
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchAgents("https://grid.example.com", async () => "token");
+
+    expect(result.map((agent) => agent.name)).toEqual(["agent-alpha", "agent-beta", "agent-tome"]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
+      "https://grid.example.com/api/user/accessible-agents?page=1&page_size=100",
+    );
+    expect(String(fetchMock.mock.calls[1]?.[0])).toBe(
+      "https://grid.example.com/api/user/accessible-agents?page=2&page_size=100",
+    );
+  });
+
+  it("does not reuse an agent cache from another server", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        Response.json({
+          success: true,
+          data: {
+            agents: [{ id: "agent-alpha", name: "Alpha", description: "" }],
+            total: 1,
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        Response.json({
+          success: true,
+          data: {
+            agents: [{ id: "agent-beta", name: "Beta", description: "" }],
+            total: 1,
+          },
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const first = await fetchAgents("https://primary.example.com", async () => "token");
+    const second = await fetchAgents("https://secondary.example.com", async () => "token");
+
+    expect(first.map((agent) => agent.name)).toEqual(["agent-alpha"]);
+    expect(second.map((agent) => agent.name)).toEqual(["agent-beta"]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("reuses a fresh agent cache for the same server", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      Response.json({
+        success: true,
+        data: {
+          agents: [{ id: "agent-alpha", name: "Alpha", description: "" }],
+          total: 1,
+        },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchAgents("https://grid.example.com", async () => "token");
+    const cached = await fetchAgents("https://grid.example.com", async () => "token");
+
+    expect(cached.map((agent) => agent.name)).toEqual(["agent-alpha"]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails when pagination stops making progress", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        Response.json({
+          success: true,
+          data: {
+            agents: [{ id: "agent-alpha", name: "Alpha", description: "" }],
+            total: 2,
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        Response.json({
+          success: true,
+          data: { agents: [], total: 2 },
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchAgents("https://grid.example.com", async () => "token")).rejects.toThrow(
+      "pagination stopped after 1 of 2 agents",
+    );
   });
 });

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -7,7 +7,10 @@
  */
 
 import { createHash } from "node:crypto";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { type TokenSet, clearTokens, loadTokens, storeTokens } from "../src/auth/keychain";
 // ── Import under test ────────────────────────────────────────────────────────
@@ -197,6 +200,25 @@ describe("loginDevice polling behavior", () => {
 
   const SERVER_URL = "https://caipe.test";
   const CLIENT_ID = "caipe-cli";
+  let discoveryConfigDir: string;
+  let previousXdgConfigHome: string | undefined;
+
+  beforeEach(() => {
+    previousXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    discoveryConfigDir = mkdtempSync(join(tmpdir(), "caipe-auth-test-"));
+    process.env.XDG_CONFIG_HOME = discoveryConfigDir;
+  });
+
+  afterEach(() => {
+    if (previousXdgConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = previousXdgConfigHome;
+    rmSync(discoveryConfigDir, { recursive: true, force: true });
+  });
+
+  function discoveryMiss(url: string): Promise<Response> | undefined {
+    if (!url.includes("/.well-known/")) return undefined;
+    return Promise.resolve(new Response("Not Found", { status: 404 }));
+  }
 
   it("authorization_pending × 2 then access_token → success", async () => {
     const { loginDevice } = await import("../src/auth/oauth");
@@ -205,6 +227,8 @@ describe("loginDevice polling behavior", () => {
     const originalFetch = global.fetch;
     global.fetch = vi.fn((url: string) => {
       const u = String(url);
+      const discovery = discoveryMiss(u);
+      if (discovery) return discovery;
       // Device code request
       if (u.includes("/oauth/device/code")) {
         return Promise.resolve(
@@ -263,6 +287,8 @@ describe("loginDevice polling behavior", () => {
     const originalFetch = global.fetch;
     global.fetch = vi.fn((url: string) => {
       const u = String(url);
+      const discovery = discoveryMiss(u);
+      if (discovery) return discovery;
       if (u.includes("/device/code")) {
         return Promise.resolve(
           new Response(
@@ -324,6 +350,8 @@ describe("loginDevice polling behavior", () => {
 
     global.fetch = vi.fn((url: string) => {
       const u = String(url);
+      const discovery = discoveryMiss(u);
+      if (discovery) return discovery;
       if (u.includes("/device/code")) {
         return Promise.resolve(
           new Response(
@@ -379,6 +407,8 @@ describe("loginDevice polling behavior", () => {
 
     global.fetch = vi.fn((url: string) => {
       const u = String(url);
+      const discovery = discoveryMiss(u);
+      if (discovery) return discovery;
       if (u.includes("/device/code")) {
         return Promise.resolve(
           new Response(
@@ -433,6 +463,8 @@ describe("loginDevice polling behavior", () => {
 
     global.fetch = vi.fn((url: string) => {
       const u = String(url);
+      const discovery = discoveryMiss(u);
+      if (discovery) return discovery;
       if (u.includes("/device/code")) {
         return Promise.resolve(
           new Response(JSON.stringify({ error: "unsupported_grant_type" }), {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,7 +1,7 @@
 /**
  * Unit tests for platform/config.ts:
  *   - getAuthUrl() priority order (flag > CAIPE_AUTH_URL > settings.auth.url > settings.server.url > throws)
- *   - getServerUrl() deprecated alias behaviour
+ *   - getServerUrl() priority order
  *   - ServerNotConfigured error
  *   - settings read/write round-trip
  *   - HTTPS validation
@@ -143,7 +143,7 @@ describe("getAuthUrl", () => {
 
 // ── getServerUrl deprecated alias ─────────────────────────────────────────────
 
-describe("getServerUrl (deprecated alias for getAuthUrl)", () => {
+describe("getServerUrl", () => {
   it("throws ServerNotConfigured when nothing is set", () => {
     expect(() => getServerUrl()).toThrow(ServerNotConfigured);
   });
@@ -153,10 +153,10 @@ describe("getServerUrl (deprecated alias for getAuthUrl)", () => {
     expect(url).toBe("https://flag.example.com");
   });
 
-  it("reads CAIPE_AUTH_URL env var (not CAIPE_SERVER_URL)", () => {
-    process.env.CAIPE_AUTH_URL = "https://auth-env.example.com";
+  it("reads CAIPE_SERVER_URL env var", () => {
+    process.env.CAIPE_SERVER_URL = "https://server-env.example.com";
     const url = getServerUrl();
-    expect(url).toBe("https://auth-env.example.com");
+    expect(url).toBe("https://server-env.example.com");
   });
 
   it("falls back to settings.server.url for backward compat", () => {
@@ -180,7 +180,7 @@ describe("authEndpoints", () => {
     const ep = authEndpoints("https://caipe.example.com");
     expect(ep.deviceCode).toBe("https://caipe.example.com/oauth/device/code");
     expect(ep.token).toBe("https://caipe.example.com/oauth/token");
-    expect(ep.agents).toBe("https://caipe.example.com/api/v1/agents");
+    expect(ep.agents).toBe("https://caipe.example.com/api/user/accessible-agents");
     expect(ep.agentCard).toBe("https://caipe.example.com/.well-known/agent.json");
     expect(ep.streamStart).toBe("https://caipe.example.com/api/v1/chat/stream/start");
   });

--- a/tests/diff.test.ts
+++ b/tests/diff.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { isUnifiedDiffText } from "../src/platform/diff.js";
+import { isUnifiedDiffText, renderDiff } from "../src/platform/diff.js";
 
 describe("isUnifiedDiffText", () => {
   const envBackup = { ...process.env };
@@ -11,5 +11,13 @@ describe("isUnifiedDiffText", () => {
   it("detects unified diff headers", () => {
     const raw = "--- a\n+++ b\n-old\n+new";
     expect(isUnifiedDiffText(raw)).toBe(true);
+  });
+
+  it("detects ANSI-colored rendered diffs", () => {
+    delete process.env.NO_COLOR;
+    const rendered = renderDiff("old\n", "new\n", "example.txt");
+
+    expect(rendered).toContain("\x1b[");
+    expect(isUnifiedDiffText(rendered)).toBe(true);
   });
 });

--- a/tests/stream.test.ts
+++ b/tests/stream.test.ts
@@ -240,7 +240,7 @@ describe("AguiAdapter", () => {
     }
   });
 
-  it("uses agentName from payload when agent name is 'default'", async () => {
+  it("uses the resolved adapter agent instead of stale payload metadata", async () => {
     let capturedBody = "";
     const originalFetch = global.fetch;
     global.fetch = vi.fn((_url, init) => {
@@ -249,14 +249,15 @@ describe("AguiAdapter", () => {
     }) as unknown as typeof fetch;
 
     try {
-      const customPayload: SendPayload = { ...PAYLOAD, agentName: "my-agent" };
-      const adapter = new AguiAdapter(DEFAULT_AGENT, SERVER_URL, getToken);
+      const customPayload: SendPayload = { ...PAYLOAD, agentName: "stale-agent" };
+      const resolvedAgent = { ...DEFAULT_AGENT, name: "resolved-agent" };
+      const adapter = new AguiAdapter(resolvedAgent, SERVER_URL, getToken);
       for await (const _ of adapter.connect(customPayload)) {
         /* drain */
       }
 
       const body = JSON.parse(capturedBody) as Record<string, unknown>;
-      expect(body.agent_id).toBe("my-agent");
+      expect(body.agent_id).toBe("resolved-agent");
     } finally {
       global.fetch = originalFetch;
     }


### PR DESCRIPTION
## Summary

- fetch every page from `/api/user/accessible-agents` using the response `total`
- request the API maximum of 100 agents per page
- reject stalled or runaway pagination instead of silently returning a partial list
- scope the five-minute agent cache to its server URL
- restore the documented first-run configuration behavior
- isolate OAuth discovery tests from machine-local caches
- recognize ANSI-colored unified diffs and align stream/config tests with current APIs

## Why

`caipe agents list` previously fetched only the default first page of 25 agents. Globally shared agents sorted onto later pages, including Tome Agent on Grid, were therefore missing from the CLI even though OpenFGA correctly granted access.

The repository CI also contained cross-platform failures caused by implicit localhost configuration, OAuth discovery cache leakage, stale endpoint expectations, and ANSI-sensitive diff detection.

## Validation

- `bun run test` — 29 files, 211 tests passed
- `bunx tsc --noEmit` — passed
- `bun run lint` — passed with 18 existing warnings
- Bun Node-target build — passed
- GitHub Actions macOS 14 — passed
- GitHub Actions Ubuntu 24.04 — passed
- DCO — passed