### PR TITLE
feat(cli): improve session orientation and diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ caipe agents list
 caipe chat --agent '<id-from-agents-list>'
 ```
 
-Type messages at the `❯` prompt. **`/`** for commands, **`Ctrl+O`** to pick an agent, **`Ctrl+D`** to exit.
+Type messages at the `❯` prompt. **`/`** for commands, **`/status`** for the active context,
+**`Ctrl+O`** to pick an agent, and **`Ctrl+D`** to exit. If setup or connectivity
+looks wrong, run **`caipe doctor`** for an actionable diagnostic report.
 
 Prompt line editing is implemented in-tree (`src/chat/line-edit.ts`, Apache-2.0): common bash/emacs keys (Ctrl+A/E/K/U/W/Y, Alt+b/f/d, Ctrl+R history search, etc.). It does **not** use GNU Readline or other GPL line-editing libraries.
 
@@ -285,6 +287,7 @@ Shared flags on `caipe kb`: `--kb-url`, `--token`, `--tenant-id` (or `CAIPE_TENA
 |---------|-------------|
 | `caipe` / `caipe chat` | Interactive REPL |
 | `caipe auth login\|logout\|status` | OAuth session |
+| `caipe doctor` | Diagnose configuration, authentication, and agent connectivity |
 | `caipe config set\|get\|unset\|discover` | Settings (`discover` sets `auth.url` via well-known URLs or deployment hostname heuristics) |
 | `caipe agents list\|info` | Server agents |
 | `caipe kb …` | KB query, read chunks, ingest, jobs, RBAC (`user info`) — JSON only |

--- a/src/chat/Repl.tsx
+++ b/src/chat/Repl.tsx
@@ -64,6 +64,7 @@ import { parseInput, pipeThrough, runShellCommand } from "./pipes.js";
 import { extractRecap } from "./recap.js";
 import { type ShellApprovalRequest, isShellHitlEnabled } from "./shell-hitl.js";
 import { FOOTER_HINT_IDLE, SHORTCUT_AGENT_PICKER, SHORTCUT_SLASH_COMMANDS } from "./shortcuts.js";
+import { formatSessionStatus } from "./status.js";
 import { createAdapter } from "./stream.js";
 import type { StreamAdapter } from "./stream.js";
 import { commandFromToolArgsBuffer } from "./tool-detail.js";
@@ -134,6 +135,7 @@ const SLASH_COMMANDS: SlashCommand[] = [
   { name: "/compact", description: "Summarize and compress history" },
   { name: "/login", description: "Re-authenticate (opens browser)" },
   { name: "/settings", description: "View or edit CLI configuration" },
+  { name: "/status", description: "Show session, agent, and server context" },
   { name: "/exit", description: "End session and save history" },
   { name: "/skills", description: "Show skills loaded in supervisor" },
   { name: "/agents", description: "Switch to a different agent" },
@@ -688,6 +690,14 @@ export function Repl({
     [pushStatic],
   );
 
+  /** Local CLI output that should not be sent back to the agent as chat history. */
+  const pushSystemPlain = useCallback(
+    (text: string) => {
+      pushStatic({ kind: "assistant-plain", text });
+    },
+    [pushStatic],
+  );
+
   // Restore saved transcript when resuming a session (`caipe chat --resume <id>`).
   const applySessionTranscript = useCallback((loaded: ChatSession) => {
     const items: StaticItem[] = [];
@@ -1228,6 +1238,22 @@ export function Repl({
           setPickerIndex(0);
           break;
 
+        case "/status": {
+          const active = activeSessionRef.current;
+          pushSystemPlain(
+            formatSessionStatus({
+              agent: currentAgent,
+              serverUrl,
+              workingDir: active.repoRoot ?? active.workingDir,
+              sessionId: active.sessionId,
+              conversationId: conversationIdRef.current,
+              messageCount: historyRef.current.length,
+              approxTokens: tokenCountRef.current,
+            }),
+          );
+          break;
+        }
+
         case "/skills":
           setStatusText("Loading skills from supervisor…");
           try {
@@ -1408,8 +1434,10 @@ export function Repl({
       handleExit,
       pushAssistant,
       pushAssistantPlain,
+      pushSystemPlain,
       streaming,
       serverUrl,
+      currentAgent,
       switchToAgent,
       openAgentPicker,
       openSessionPicker,

--- a/src/chat/runner.ts
+++ b/src/chat/runner.ts
@@ -17,7 +17,8 @@ import {
   getAuthUrl,
   getServerUrl,
 } from "../platform/config.js";
-import { printLogo } from "../platform/display.js";
+import { printSessionBanner } from "../platform/display.js";
+import { findRepoRoot } from "../platform/git.js";
 import { getTerminalCapabilities } from "../platform/markdown.js";
 import { runSetupWizard } from "../platform/setup.js";
 import {
@@ -96,8 +97,6 @@ export async function runChat(opts: ChatOpts, globalOpts: GlobalOpts): Promise<v
     enterAlternateScreen();
   }
 
-  printLogo();
-
   // Stream endpoint: caipe-ui BFF (may differ from authUrl when KC is separate)
   let serverUrl: string;
   try {
@@ -107,6 +106,7 @@ export async function runChat(opts: ChatOpts, globalOpts: GlobalOpts): Promise<v
   }
 
   const getToken = () => getValidToken(authUrl);
+  const cwd = process.cwd();
 
   let resolvedAgent: Agent;
   try {
@@ -116,9 +116,17 @@ export async function runChat(opts: ChatOpts, globalOpts: GlobalOpts): Promise<v
     process.exit(3);
   }
   const agentName = resolvedAgent.name;
+  const repoRoot = await findRepoRoot(cwd);
+
+  printSessionBanner({
+    agentName,
+    agentDisplayName: resolvedAgent.displayName,
+    serverUrl,
+    workingDir: repoRoot ?? cwd,
+    resumed: Boolean(opts.resume),
+  });
 
   // Gather context (inject agents + skills for richer system prompt)
-  const cwd = process.cwd();
   const systemContext = await buildSystemContext(cwd, opts.noContext ?? false, {
     serverUrl,
     getToken,
@@ -132,13 +140,16 @@ export async function runChat(opts: ChatOpts, globalOpts: GlobalOpts): Promise<v
     if (!existing) {
       process.stderr.write(`[WARN] Session ${opts.resume} not found; starting a new session.\n`);
       session = createSession({ agentName, workingDir: cwd });
+      session.repoRoot = repoRoot;
       session.memoryContext = systemContext;
     } else {
       session = existing;
       session.workingDir = cwd;
+      session.repoRoot = repoRoot;
     }
   } else {
     session = createSession({ agentName, workingDir: cwd });
+    session.repoRoot = repoRoot;
     session.memoryContext = systemContext;
   }
 

--- a/src/chat/status.ts
+++ b/src/chat/status.ts
@@ -1,0 +1,38 @@
+import type { Agent } from "../agents/types.js";
+
+export interface SessionStatusInfo {
+  agent: Agent;
+  serverUrl?: string;
+  workingDir: string;
+  sessionId: string;
+  conversationId?: string;
+  messageCount: number;
+  approxTokens: number;
+}
+
+function displayServer(serverUrl?: string): string {
+  if (!serverUrl) return "(not configured)";
+  try {
+    return new URL(serverUrl).host;
+  } catch {
+    return serverUrl;
+  }
+}
+
+/** Stable, plain-text session summary for `/status`. */
+export function formatSessionStatus(info: SessionStatusInfo): string {
+  const agent =
+    info.agent.displayName === info.agent.name
+      ? info.agent.name
+      : `${info.agent.displayName} (${info.agent.name})`;
+  const row = (label: string, value: string): string => `  ${label.padEnd(13)}${value}`;
+  return [
+    "Session status",
+    row("agent", agent),
+    row("server", displayServer(info.serverUrl)),
+    row("workspace", info.workingDir),
+    row("session", info.sessionId.slice(0, 8)),
+    row("conversation", info.conversationId ? "linked" : "local only"),
+    row("context", `${info.messageCount} messages · ~${info.approxTokens} tokens`),
+  ].join("\n");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,8 +16,10 @@ const program = new Command();
 
 program
   .name("caipe")
-  .description("Custom Agents, workflows and more... caipe.io")
+  .description("Chat with CAIPE agents from your terminal")
   .version(pkg.version, "-v, --version", "Print version and exit")
+  .showSuggestionAfterError(true)
+  .showHelpAfterError("Run `caipe --help` to see available commands.")
   .option(
     "--agent <name>",
     "Dynamic agent id from `caipe agents list` (default: agent.default setting, else first accessible)",
@@ -26,6 +28,18 @@ program
   .option("--url <url>", "Override server.url from settings.json for this invocation only")
   .option("--no-color", "Disable ANSI color output")
   .option("--json", "Machine-readable JSON output (non-interactive commands only)");
+
+program.addHelpText(
+  "after",
+  [
+    "",
+    "Examples:",
+    "  $ caipe                         Start an interactive chat",
+    "  $ caipe chat --agent primary    Chat with a specific agent",
+    "  $ caipe doctor                  Diagnose setup and connectivity",
+    "  $ caipe agents list             List accessible agents",
+  ].join("\n"),
+);
 
 // ---------------------------------------------------------------------------
 // caipe chat
@@ -399,6 +413,19 @@ program
   .action(async (opts: Record<string, unknown>) => {
     const { runCommit } = await import("./commit/commands.js");
     await runCommit(opts);
+  });
+
+// ---------------------------------------------------------------------------
+// caipe doctor
+// ---------------------------------------------------------------------------
+program
+  .command("doctor")
+  .description("Check configuration, authentication, and agent connectivity")
+  .option("--json", "Output the diagnostic report as JSON")
+  .action(async (opts: Record<string, unknown>) => {
+    const { runDoctor } = await import("./platform/doctor.js");
+    const ok = await runDoctor({ json: opts.json === true || program.opts().json === true });
+    if (!ok) process.exitCode = 1;
   });
 
 // ---------------------------------------------------------------------------

--- a/src/platform/display.tsx
+++ b/src/platform/display.tsx
@@ -1,47 +1,64 @@
 /**
- * Display utilities: ASCII logo, spinners, and progress indicators.
+ * Display utilities: session banner, spinners, and progress indicators.
  *
  * All output respects NO_COLOR.  The logo is printed once at interactive
  * session startup.  Spinners are React/Ink components used in the REPL.
  */
 
+import { homedir } from "node:os";
 import { Box, Text } from "ink";
 import React from "react";
 
 const NO_COLOR = Boolean(process.env.NO_COLOR);
 
 // ---------------------------------------------------------------------------
-// ASCII logo
+// Session banner
 // ---------------------------------------------------------------------------
 
-const LOGO_LINES = [
-  "  ██████╗ █████╗ ██╗██████╗ ███████╗",
-  " ██╔════╝██╔══██╗██║██╔══██╗██╔════╝",
-  " ██║     ███████║██║██████╔╝█████╗  ",
-  " ██║     ██╔══██║██║██╔═══╝ ██╔══╝  ",
-  " ╚██████╗██║  ██║██║██║     ███████╗",
-  "  ╚═════╝╚═╝  ╚═╝╚═╝╚═╝     ╚══════╝",
-];
-
-const TAGLINE = "Custom Agents, workflows and more... caipe.io";
 const CYAN = NO_COLOR ? "" : "\x1b[96m";
+const DIM = NO_COLOR ? "" : "\x1b[2m";
 const RESET = NO_COLOR ? "" : "\x1b[0m";
 
-/**
- * Print the CAIPE ASCII logo to stdout.
- * Called once when an interactive chat session starts.
- */
-export function printLogo(): void {
-  if (NO_COLOR) {
-    process.stdout.write("CAIPE\n");
-    process.stdout.write(`${TAGLINE}\n\n`);
-    return;
+export interface SessionBannerInfo {
+  agentName: string;
+  agentDisplayName: string;
+  serverUrl: string;
+  workingDir: string;
+  resumed?: boolean;
+}
+
+function compactHome(path: string): string {
+  const home = homedir();
+  return path === home ? "~" : path.startsWith(`${home}/`) ? `~${path.slice(home.length)}` : path;
+}
+
+function serverHost(serverUrl: string): string {
+  try {
+    return new URL(serverUrl).host;
+  } catch {
+    return serverUrl;
   }
-  process.stdout.write("\n");
-  for (const line of LOGO_LINES) {
-    process.stdout.write(`${CYAN}${line}${RESET}\n`);
-  }
-  process.stdout.write(`\n  ${TAGLINE}\n\n`);
+}
+
+/** Compact startup context, inspired by modern coding-agent CLIs. */
+export function formatSessionBanner(info: SessionBannerInfo): string {
+  const displayAgent =
+    info.agentDisplayName === info.agentName
+      ? info.agentName
+      : `${info.agentDisplayName} (${info.agentName})`;
+  const resume = info.resumed ? " · resumed" : "";
+  return [
+    `${CYAN}CAIPE${RESET}${resume}`,
+    `  ${DIM}agent${RESET}     ${displayAgent}`,
+    `  ${DIM}workspace${RESET} ${compactHome(info.workingDir)}`,
+    `  ${DIM}server${RESET}    ${serverHost(info.serverUrl)}`,
+    `  ${DIM}hint${RESET}      / commands · Ctrl+O agents`,
+    "",
+  ].join("\n");
+}
+
+export function printSessionBanner(info: SessionBannerInfo): void {
+  process.stdout.write(formatSessionBanner(info));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/platform/doctor.ts
+++ b/src/platform/doctor.ts
@@ -1,0 +1,152 @@
+import pkg from "../../package.json";
+import { fetchAgents } from "../agents/registry.js";
+import { loadTokens } from "../auth/keychain.js";
+import type { TokenSet } from "../auth/keychain.js";
+import { isExpired } from "../auth/tokens.js";
+import { getAuthUrl, getServerUrl } from "./config.js";
+
+export type DoctorStatus = "pass" | "warn" | "fail";
+
+export interface DoctorCheck {
+  name: string;
+  status: DoctorStatus;
+  detail: string;
+  fix?: string;
+}
+
+export interface DoctorReport {
+  ok: boolean;
+  version: string;
+  checks: DoctorCheck[];
+}
+
+export interface DoctorDependencies {
+  getServerUrl: () => string;
+  getAuthUrl: () => string;
+  loadTokens: () => Promise<TokenSet | null>;
+  isExpired: (tokens: TokenSet) => boolean;
+  fetchAgents: (serverUrl: string, getToken: () => Promise<string>) => Promise<unknown[]>;
+}
+
+const defaultDependencies: DoctorDependencies = {
+  getServerUrl,
+  getAuthUrl,
+  loadTokens,
+  isExpired,
+  fetchAgents,
+};
+
+function configuredUrl(
+  name: string,
+  resolve: () => string,
+  fix: string,
+): { value?: string; check: DoctorCheck } {
+  try {
+    const value = resolve();
+    return { value, check: { name, status: "pass", detail: value } };
+  } catch (error) {
+    return {
+      check: {
+        name,
+        status: "fail",
+        detail: error instanceof Error ? error.message : String(error),
+        fix,
+      },
+    };
+  }
+}
+
+export async function collectDoctorReport(
+  dependencies: DoctorDependencies = defaultDependencies,
+): Promise<DoctorReport> {
+  const checks: DoctorCheck[] = [
+    {
+      name: "Runtime",
+      status: "pass",
+      detail: `CAIPE ${pkg.version} · Node ${process.versions.node} · ${process.platform}/${process.arch}`,
+    },
+  ];
+
+  const server = configuredUrl(
+    "Server",
+    dependencies.getServerUrl,
+    "caipe config set server.url https://bff.example.com",
+  );
+  const auth = configuredUrl(
+    "OAuth",
+    dependencies.getAuthUrl,
+    "caipe config set auth.url https://idp.example.com/realms/example",
+  );
+  checks.push(server.check, auth.check);
+
+  const tokens = await dependencies.loadTokens();
+  if (!tokens) {
+    checks.push({
+      name: "Authentication",
+      status: "fail",
+      detail: "No stored session",
+      fix: "caipe auth login",
+    });
+  } else if (dependencies.isExpired(tokens)) {
+    checks.push({
+      name: "Authentication",
+      status: "fail",
+      detail: `Session expired${tokens.identity ? ` for ${tokens.identity}` : ""}`,
+      fix: "caipe auth login --force",
+    });
+  } else {
+    checks.push({
+      name: "Authentication",
+      status: "pass",
+      detail: tokens.displayName || tokens.email || tokens.identity || "Authenticated",
+    });
+  }
+
+  if (server.value && tokens && !dependencies.isExpired(tokens)) {
+    try {
+      const agents = await dependencies.fetchAgents(server.value, async () => tokens.accessToken);
+      checks.push({
+        name: "Agents",
+        status: "pass",
+        detail: `${agents.length} accessible agent${agents.length === 1 ? "" : "s"}`,
+      });
+    } catch (error) {
+      checks.push({
+        name: "Agents",
+        status: "fail",
+        detail: error instanceof Error ? error.message : String(error),
+        fix: "Check network access and run `caipe auth login --force`",
+      });
+    }
+  } else {
+    checks.push({
+      name: "Agents",
+      status: "warn",
+      detail: "Skipped until server and authentication checks pass",
+    });
+  }
+
+  return { ok: !checks.some((check) => check.status === "fail"), version: pkg.version, checks };
+}
+
+export function formatDoctorReport(report: DoctorReport): string {
+  const icon: Record<DoctorStatus, string> = { pass: "✓", warn: "!", fail: "✗" };
+  const lines = [`CAIPE doctor ${report.version}`, ""];
+  for (const check of report.checks) {
+    lines.push(`${icon[check.status]} ${check.name.padEnd(16)} ${check.detail}`);
+    if (check.fix) lines.push(`  Fix: ${check.fix}`);
+  }
+  lines.push(
+    "",
+    report.ok ? "Ready to chat." : "Resolve the failed checks, then run `caipe doctor` again.",
+  );
+  return `${lines.join("\n")}\n`;
+}
+
+export async function runDoctor(options: { json?: boolean } = {}): Promise<boolean> {
+  const report = await collectDoctorReport();
+  process.stdout.write(
+    options.json ? `${JSON.stringify(report, null, 2)}\n` : formatDoctorReport(report),
+  );
+  return report.ok;
+}

--- a/tests/cli.e2e.test.ts
+++ b/tests/cli.e2e.test.ts
@@ -2,6 +2,8 @@
  * E2E: CLI entrypoints (Node/tsx — not raw Bun binaries on PATH).
  */
 
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { execa } from "execa";
@@ -45,6 +47,34 @@ describe("bin/caipe.cjs", () => {
     });
     expect(exitCode).toBe(0);
     expect(stdout).toMatch(/chat|config|auth/i);
+    expect(stdout).toContain("doctor");
+    expect(stdout).toContain("Examples:");
+  });
+
+  it("prints actionable doctor JSON and exits non-zero when setup is missing", async () => {
+    const configHome = mkdtempSync(join(tmpdir(), "caipe-doctor-e2e-"));
+    try {
+      const { stdout, exitCode } = await execa(process.execPath, [launcher, "doctor", "--json"], {
+        cwd: root,
+        env: { ...nodeEnv, XDG_CONFIG_HOME: configHome },
+        reject: false,
+      });
+      const report = JSON.parse(stdout) as {
+        ok: boolean;
+        checks: Array<{ name: string; status: string; fix?: string }>;
+      };
+
+      expect(exitCode).toBe(1);
+      expect(report.ok).toBe(false);
+      expect(report.checks).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: "Server", status: "fail" }),
+          expect.objectContaining({ name: "Authentication", fix: "caipe auth login" }),
+        ]),
+      );
+    } finally {
+      rmSync(configHome, { recursive: true, force: true });
+    }
   });
 });
 

--- a/tests/display.test.ts
+++ b/tests/display.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { formatSessionBanner } from "../src/platform/display.js";
+
+describe("formatSessionBanner", () => {
+  it("shows agent, workspace, server, and shortcuts without the oversized logo", () => {
+    const text = formatSessionBanner({
+      agentName: "primary",
+      agentDisplayName: "Primary Agent",
+      serverUrl: "https://grid.example.com/api",
+      workingDir: "/workspace/example",
+      resumed: true,
+    });
+
+    expect(text).toContain("CAIPE");
+    expect(text).toContain("resumed");
+    expect(text).toContain("Primary Agent (primary)");
+    expect(text).toContain("grid.example.com");
+    expect(text).toContain("/ commands · Ctrl+O agents");
+    expect(text).not.toContain("██████");
+  });
+});

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  type DoctorDependencies,
+  collectDoctorReport,
+  formatDoctorReport,
+} from "../src/platform/doctor.js";
+
+function dependencies(overrides: Partial<DoctorDependencies> = {}): DoctorDependencies {
+  return {
+    getServerUrl: () => "https://grid.example.com",
+    getAuthUrl: () => "https://idp.example.com/realms/example",
+    loadTokens: async () => ({ accessToken: "token", identity: "test-user@example.com" }),
+    isExpired: () => false,
+    fetchAgents: async () => [{ name: "primary" }, { name: "secondary" }],
+    ...overrides,
+  };
+}
+
+describe("collectDoctorReport", () => {
+  it("reports a healthy CLI", async () => {
+    const report = await collectDoctorReport(dependencies());
+
+    expect(report.ok).toBe(true);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "Authentication", status: "pass" }),
+        expect.objectContaining({ name: "Agents", status: "pass", detail: "2 accessible agents" }),
+      ]),
+    );
+    expect(formatDoctorReport(report)).toContain("Ready to chat.");
+  });
+
+  it("provides next commands when setup is incomplete", async () => {
+    const report = await collectDoctorReport(
+      dependencies({
+        getServerUrl: () => {
+          throw new Error("Server missing");
+        },
+        getAuthUrl: () => {
+          throw new Error("OAuth missing");
+        },
+        loadTokens: async () => null,
+      }),
+    );
+
+    expect(report.ok).toBe(false);
+    const text = formatDoctorReport(report);
+    expect(text).toContain("caipe config set server.url");
+    expect(text).toContain("caipe auth login");
+    expect(text).toContain("Skipped until server and authentication checks pass");
+  });
+});

--- a/tests/status.test.ts
+++ b/tests/status.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_AGENT } from "../src/agents/types.js";
+import { formatSessionStatus } from "../src/chat/status.js";
+
+describe("formatSessionStatus", () => {
+  it("shows the active execution context", () => {
+    const text = formatSessionStatus({
+      agent: { ...DEFAULT_AGENT, name: "primary", displayName: "Primary Agent" },
+      serverUrl: "https://grid.example.com/path",
+      workingDir: "/workspace/example",
+      sessionId: "12345678-abcd",
+      conversationId: "conversation-1",
+      messageCount: 4,
+      approxTokens: 120,
+    });
+
+    expect(text).toContain("Primary Agent (primary)");
+    expect(text).toContain("grid.example.com");
+    expect(text).toContain("/workspace/example");
+    expect(text).toContain("12345678");
+    expect(text).toContain("linked");
+    expect(text).toContain("4 messages · ~120 tokens");
+  });
+});


### PR DESCRIPTION
## Summary

- replace the oversized startup logo with a compact agent, workspace, server, and shortcut context banner
- add `/status` for active agent, server, workspace, session, conversation, and context usage
- add `caipe doctor` and `caipe doctor --json` for configuration, OAuth, and accessible-agent diagnostics
- provide actionable recovery commands for missing setup, expired authentication, and registry failures
- improve top-level help with clearer copy, examples, typo suggestions, and post-error guidance
- keep local status output out of model conversation history

## UX rationale

This follows the most useful conventions shared by modern agent CLIs such as Claude Code and Codex: orient users immediately, expose the current execution context in-session, and make setup failures self-diagnosing. The change stays CAIPE-specific rather than copying unsupported coding-agent controls.

## Validation

- `bun run test` — 32 files, 216 tests passed
- `bunx tsc --noEmit` — passed
- `bun run lint` — passed with 18 existing warnings
- Bun Node-target build — passed
- exercised `caipe doctor --json` against isolated missing config
- exercised `caipe doctor --json` against the configured Grid environment; it correctly identified the expired local session and suggested `caipe auth login --force`

## Dependency

Stacked on #40 so the agent pagination and baseline CI fixes remain independently reviewable. Rebase onto `main` after #40 merges.