### PR TITLE
feat(cli): add accessible terminal themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ Type messages at the `❯` prompt. **`/`** for commands, **`/status`** for the a
 **`Ctrl+O`** to pick an agent, and **`Ctrl+D`** to exit. If setup or connectivity
 looks wrong, run **`caipe doctor`** for an actionable diagnostic report.
 
+Use **`/theme`** inside chat to inspect color themes, or switch immediately with
+`/theme dark`, `/theme light`, `/theme high-contrast`, `/theme mono`, or `/theme auto`.
+Persist the choice with `caipe config set ui.theme <name>`. `CAIPE_THEME` overrides
+the saved setting, while `NO_COLOR` always disables color.
+
 Prompt line editing is implemented in-tree (`src/chat/line-edit.ts`, Apache-2.0): common bash/emacs keys (Ctrl+A/E/K/U/W/Y, Alt+b/f/d, Ctrl+R history search, etc.). It does **not** use GNU Readline or other GPL line-editing libraries.
 
 Other host (UI serves OAuth on the same URL): set only `server.url`, then `caipe auth login` and `caipe chat`.
@@ -169,6 +174,7 @@ caipe config set auth.idp-hint duo-sso
 | `CAIPE_SERVER_URL` | BFF base URL (agents, chat stream) |
 | `CAIPE_AUTH_URL` | OAuth / discovery base (login) |
 | `CAIPE_DEFAULT_AGENT` | Default dynamic agent id (overrides `agent.default` in settings) |
+| `CAIPE_THEME` | Terminal theme: `auto`, `dark`, `light`, `high-contrast`, or `mono` |
 | `CAIPE_AUTH_REALM` | Keycloak realm name for IdP heuristics (default `caipe`) |
 | `CAIPE_PLAIN_TERMINAL` | Set to `1` to disable rich markdown, alt screen, and inline images |
 | `CAIPE_NO_ALT_SCREEN` | Set to `1` to keep chat in the normal scrollback buffer |
@@ -272,10 +278,11 @@ Shared flags on `caipe kb`: `--kb-url`, `--token`, `--tenant-id` (or `CAIPE_TENA
 | `agent.default` | Default dynamic agent id for `caipe chat` when `--agent` is omitted |
 | `auth.idp-hint` | Skip Keycloak login chooser (`kc_idp_hint`) |
 | `kb.url` | Knowledge Base RAG REST API base URL |
-
-**Rich terminal output (interactive chat):** Markdown is rendered with **react-markdown** + **remark-gfm** as native Ink components (no ANSI markdown strings). Diffs use Ink colors. Block streaming caches completed sections in `<Static>`; the active tail updates in place. Tool runs show in the footer. Chat uses the **alternate screen** unless `CAIPE_NO_ALT_SCREEN=1` or `CAIPE_PLAIN_TERMINAL=1`. Legacy plain streaming: `CAIPE_STREAM_PLAIN=1`.
+| `ui.theme` | Terminal theme: `auto`, `dark`, `light`, `high-contrast`, or `mono` |
 | `auth.apiKey` | Static API key (headless alternative) |
 | `auth.credential-storage` | `encrypted-file` (default) or `keychain` |
+
+**Rich terminal output (interactive chat):** Markdown is rendered with **react-markdown** + **remark-gfm** as native Ink components (no ANSI markdown strings). Diffs use Ink colors. Block streaming caches completed sections in `<Static>`; the active tail updates in place. Tool runs show in the footer. Chat uses the **alternate screen** unless `CAIPE_NO_ALT_SCREEN=1` or `CAIPE_PLAIN_TERMINAL=1`. Legacy plain streaming: `CAIPE_STREAM_PLAIN=1`.
 
 **Default credentials:** encrypted file at `~/.config/caipe/credentials.enc` (AES-256-GCM, machine-derived key). No Keychain prompts unless you opt into `keychain`.
 

--- a/src/agents/AgentPicker.tsx
+++ b/src/agents/AgentPicker.tsx
@@ -7,6 +7,7 @@ import type React from "react";
 
 import { PICKER_HINT_NAV } from "../chat/shortcuts.js";
 import { isRichTerminalEnabled } from "../platform/terminal/capabilities.js";
+import { getTerminalTheme } from "../platform/theme.js";
 import { pickerWindow, truncateText } from "./picker.js";
 import type { Agent } from "./types.js";
 
@@ -34,9 +35,16 @@ export function AgentPicker({
   filter,
   visibleRowCount = 8,
 }: AgentPickerProps): React.ReactElement {
+  const theme = getTerminalTheme();
   if (agents.length === 0) {
     return (
-      <Box flexDirection="column" borderStyle="round" borderColor="yellow" marginX={1} paddingX={1}>
+      <Box
+        flexDirection="column"
+        borderStyle="round"
+        borderColor={theme.warning}
+        marginX={1}
+        paddingX={1}
+      >
         <Text dimColor>No agents match {filter ? `"${filter}"` : "filter"}.</Text>
       </Box>
     );
@@ -49,9 +57,15 @@ export function AgentPicker({
   const slice = agents.slice(start, end);
 
   return (
-    <Box flexDirection="column" borderStyle="round" borderColor="cyan" marginX={1} paddingX={1}>
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={theme.accent}
+      marginX={1}
+      paddingX={1}
+    >
       <Box marginBottom={0}>
-        <Text bold color="cyan">
+        <Text bold color={theme.accent}>
           Select agent
         </Text>
         <Text dimColor>
@@ -69,8 +83,8 @@ export function AgentPicker({
         const descLine = selected ? truncateText(desc, DESC_SELECTED_MAX) : "";
         const num = String(idx + 1).padStart(2, " ");
 
-        const rowBg = selected && rich ? "blue" : undefined;
-        const titleColor = selected ? (rich ? "white" : "cyan") : undefined;
+        const rowBg = selected && rich ? theme.selectedBackground : undefined;
+        const titleColor = selected ? (rich ? theme.selectedForeground : theme.accent) : undefined;
         const titleDim = !selected;
 
         return (
@@ -82,7 +96,7 @@ export function AgentPicker({
                 <Text
                   backgroundColor={rowBg}
                   bold={selected}
-                  color={selected ? "cyan" : undefined}
+                  color={selected ? theme.accent : undefined}
                   dimColor={!selected}
                 >
                   {`${num} `}
@@ -108,7 +122,7 @@ export function AgentPicker({
                   <Text
                     backgroundColor={rowBg}
                     bold={selected}
-                    color={selected && rich ? "white" : undefined}
+                    color={selected && rich ? theme.selectedForeground : undefined}
                     dimColor={!selected || !rich}
                   >
                     {" · in session"}
@@ -120,7 +134,7 @@ export function AgentPicker({
                   <Box paddingLeft={2}>
                     <Text
                       backgroundColor={rowBg}
-                      color={rich ? "white" : "cyan"}
+                      color={rich ? theme.selectedForeground : theme.accent}
                       dimColor={!rich}
                       wrap="truncate"
                     >
@@ -130,7 +144,7 @@ export function AgentPicker({
                   <Box paddingLeft={2}>
                     <Text
                       backgroundColor={rowBg}
-                      color={rich ? "white" : undefined}
+                      color={rich ? theme.selectedForeground : undefined}
                       dimColor={!rich}
                       wrap="wrap"
                     >
@@ -145,11 +159,11 @@ export function AgentPicker({
       })}
       {end < agents.length ? <Text dimColor>{`  ↓ ${agents.length - end} more below`}</Text> : null}
       <Box marginTop={0}>
-        <Text color="cyan" bold>
+        <Text color={theme.accent} bold>
           {`${safeIndex + 1}/${agents.length}`}
         </Text>
         <Text dimColor> · </Text>
-        <Text bold color="white">
+        <Text bold color={theme.accent}>
           {selectedAgent ? agentTitle(selectedAgent) : ""}
         </Text>
         <Text dimColor>{` · Enter switch · ${agents.length} total · or /agents <id>`}</Text>

--- a/src/agents/List.tsx
+++ b/src/agents/List.tsx
@@ -4,7 +4,8 @@
 
 import { Box, Text } from "ink";
 import type React from "react";
-import { statusDot } from "../platform/display.js";
+import { getTerminalTheme } from "../platform/theme.js";
+import { truncateText } from "./picker.js";
 import type { Agent } from "./types.js";
 
 interface AgentListProps {
@@ -12,6 +13,7 @@ interface AgentListProps {
 }
 
 export function AgentList({ agents }: AgentListProps): React.ReactElement {
+  const theme = getTerminalTheme();
   if (agents.length === 0) {
     return (
       <Box>
@@ -22,32 +24,26 @@ export function AgentList({ agents }: AgentListProps): React.ReactElement {
 
   return (
     <Box flexDirection="column">
-      {/* Header row */}
-      <Box>
-        <Text bold color="cyan">
-          {"Name".padEnd(20)}
+      <Box marginBottom={1}>
+        <Text bold color={theme.accent}>
+          Accessible agents
         </Text>
-        <Text bold color="cyan">
-          {"Domain".padEnd(14)}
-        </Text>
-        <Text bold color="cyan">
-          {"Protocols".padEnd(16)}
-        </Text>
-        <Text bold color="cyan">
-          Status
-        </Text>
-      </Box>
-      <Box>
-        <Text dimColor>{"─".repeat(60)}</Text>
+        <Text dimColor> · {agents.length} total</Text>
       </Box>
 
       {agents.map((agent) => (
-        <Box key={agent.name}>
-          <Text>{agent.name.padEnd(20)}</Text>
-          <Text dimColor>{agent.domain.padEnd(14)}</Text>
-          <Text dimColor>{(agent.protocols ?? ["agui"]).join(", ").padEnd(16)}</Text>
-          <Text>{statusDot(agent.available)}</Text>
-          <Text dimColor> {agent.displayName}</Text>
+        <Box key={agent.name} flexDirection="column" marginBottom={1}>
+          <Box>
+            <Text color={agent.available ? theme.success : theme.danger}>
+              {agent.available ? "✓ " : "✗ "}
+            </Text>
+            <Text bold>{truncateText(agent.displayName || agent.name, 64)}</Text>
+          </Box>
+          <Box paddingLeft={2}>
+            <Text dimColor wrap="truncate">
+              {agent.name} · {agent.domain} · {(agent.protocols ?? ["agui"]).join(", ")}
+            </Text>
+          </Box>
         </Box>
       ))}
     </Box>

--- a/src/agents/commands.ts
+++ b/src/agents/commands.ts
@@ -8,10 +8,22 @@ import { getValidToken } from "../auth/tokens.js";
 import { getAuthUrl, getServerUrl } from "../platform/config.js";
 import { AgentList } from "./List.js";
 import { fetchAgents, getAgent } from "./registry.js";
+import type { Agent } from "./types.js";
 
 interface GlobalOpts {
   url?: string;
   json?: boolean;
+}
+
+export function formatAgentListPlain(agents: Agent[]): string {
+  const lines = [`Accessible agents (${agents.length})`, ""];
+  for (const agent of agents) {
+    const dot = agent.available ? "✓" : "✗";
+    const display = agent.displayName.trim() || agent.name;
+    lines.push(`${dot} ${display}`);
+    lines.push(`  ${agent.name} · ${agent.domain} · ${(agent.protocols ?? ["agui"]).join(", ")}`);
+  }
+  return `${lines.join("\n")}\n`;
 }
 
 export async function runAgentsList(
@@ -42,12 +54,7 @@ export async function runAgentsList(
   }
 
   if (!process.stdout.isTTY) {
-    for (const a of agents) {
-      const dot = a.available ? "✓" : "✗";
-      process.stdout.write(
-        `${dot} ${a.name.padEnd(20)} ${a.domain.padEnd(12)} ${(a.protocols ?? ["agui"]).join(",")}\n`,
-      );
-    }
+    process.stdout.write(formatAgentListPlain(agents));
     return;
   }
 

--- a/src/chat/Repl.tsx
+++ b/src/chat/Repl.tsx
@@ -14,7 +14,7 @@ import { Box, Text, useApp, useInput, useStdout } from "ink";
 import React, { useState, useEffect, useCallback, useRef, useMemo } from "react";
 
 import { AgentPicker } from "../agents/AgentPicker.js";
-import { filterAgents, sortAgentsForPicker } from "../agents/picker.js";
+import { filterAgents, sortAgentsForPicker, truncateText } from "../agents/picker.js";
 import { fetchAgents, getAgent } from "../agents/registry.js";
 import type { Agent } from "../agents/types.js";
 import { loginBrowser } from "../auth/oauth.js";
@@ -29,6 +29,13 @@ import {
 import { ToolActivityPanel, type ToolActivityRun } from "../platform/display.js";
 import { getMarkdownLayoutWidth, getTerminalWidth } from "../platform/markdown.js";
 import { maxStaticToolTreeRows } from "../platform/terminal/repl-ui.js";
+import {
+  THEME_PREFERENCES,
+  getTerminalTheme,
+  getThemePreference,
+  parseThemePreference,
+  setThemePreference,
+} from "../platform/theme.js";
 import { fetchSupervisorSkills } from "../skills/catalog.js";
 import { SessionPicker } from "./SessionPicker.js";
 import { ShellApprovalPrompt } from "./ShellApprovalPrompt.js";
@@ -63,7 +70,12 @@ import {
 import { parseInput, pipeThrough, runShellCommand } from "./pipes.js";
 import { extractRecap } from "./recap.js";
 import { type ShellApprovalRequest, isShellHitlEnabled } from "./shell-hitl.js";
-import { FOOTER_HINT_IDLE, SHORTCUT_AGENT_PICKER, SHORTCUT_SLASH_COMMANDS } from "./shortcuts.js";
+import {
+  FOOTER_HINT_IDLE,
+  SHORTCUT_AGENT_PICKER,
+  SHORTCUT_SLASH_COMMANDS,
+  footerLayoutDirection,
+} from "./shortcuts.js";
 import { formatSessionStatus } from "./status.js";
 import { createAdapter } from "./stream.js";
 import type { StreamAdapter } from "./stream.js";
@@ -130,12 +142,21 @@ interface SlashCommand {
   description: string;
 }
 
+export function slashCommandQuery(input: string): string {
+  return input.slice(1).trimStart().split(/\s+/, 1)[0]?.toLowerCase() ?? "";
+}
+
+export function slashInputHasArguments(input: string): boolean {
+  return /^\/\S+\s+\S/.test(input);
+}
+
 const SLASH_COMMANDS: SlashCommand[] = [
   { name: "/clear", description: "Clear conversation context" },
   { name: "/compact", description: "Summarize and compress history" },
   { name: "/login", description: "Re-authenticate (opens browser)" },
   { name: "/settings", description: "View or edit CLI configuration" },
   { name: "/status", description: "Show session, agent, and server context" },
+  { name: "/theme", description: "View or switch terminal color theme" },
   { name: "/exit", description: "End session and save history" },
   { name: "/skills", description: "Show skills loaded in supervisor" },
   { name: "/agents", description: "Switch to a different agent" },
@@ -155,6 +176,7 @@ interface SlashPickerProps {
 }
 
 function SlashPicker({ input, selectedIndex, filtered }: SlashPickerProps): React.ReactElement {
+  const theme = getTerminalTheme();
   const query = input.slice(1).toLowerCase();
   const safeIndex = clampPickerIndex(selectedIndex, filtered.length);
   const { start, end } = pickerWindow(filtered.length, safeIndex, SLASH_PICKER_VISIBLE);
@@ -164,13 +186,13 @@ function SlashPicker({ input, selectedIndex, filtered }: SlashPickerProps): Reac
     <Box
       flexDirection="column"
       borderStyle="round"
-      borderColor="cyan"
+      borderColor={theme.accent}
       marginX={1}
       marginBottom={0}
       paddingX={1}
     >
       <Box>
-        <Text bold color="cyan">
+        <Text bold color={theme.accent}>
           Slash commands
         </Text>
         <Text dimColor> · ↑↓ · PgUp/PgDn · Tab complete · Enter run · Esc dismiss</Text>
@@ -185,11 +207,11 @@ function SlashPicker({ input, selectedIndex, filtered }: SlashPickerProps): Reac
             const sel = idx === safeIndex;
             return (
               <Box key={cmd.name}>
-                <Text color={sel ? "cyan" : undefined}>{sel ? "▶ " : "  "}</Text>
-                <Text color={sel ? "cyan" : "white"} bold={sel}>
+                <Text color={sel ? theme.accent : undefined}>{sel ? "▶ " : "  "}</Text>
+                <Text color={sel ? theme.accent : undefined} bold={sel}>
                   {cmd.name.padEnd(14)}
                 </Text>
-                <Text dimColor={!sel} color={sel ? "white" : undefined}>
+                <Text dimColor={!sel} color={sel ? theme.selectedForeground : undefined}>
                   {cmd.description}
                 </Text>
               </Box>
@@ -252,6 +274,7 @@ function InputBar({
   disabled = false,
   history = [],
 }: InputBarProps): React.ReactElement {
+  const theme = getTerminalTheme();
   const [cursor, setCursor] = useState(value.length);
   const [historyIdx, setHistoryIdx] = useState(history.length);
   const stashedRef = useRef("");
@@ -463,12 +486,12 @@ function InputBar({
         <Text dimColor>{`(reverse-i-search)\`${revSearch.query}': ${value}`}</Text>
       ) : null}
       <Box>
-        <Text color={disabled ? "gray" : "green"} bold>
+        <Text color={disabled ? theme.muted : theme.prompt} bold>
           {"❯ "}
         </Text>
         <Text>{before}</Text>
         {!disabled && (
-          <Text color="green" inverse>
+          <Text color={theme.prompt} inverse>
             {at || " "}
           </Text>
         )}
@@ -483,11 +506,10 @@ function InputBar({
 // HRule (memoized)
 // ---------------------------------------------------------------------------
 
-const HRule = React.memo(function HRule({
-  color = "gray",
-}: { color?: string }): React.ReactElement {
+const HRule = React.memo(function HRule(): React.ReactElement {
+  const theme = getTerminalTheme();
   const cols = Math.max(20, getMarkdownLayoutWidth("full"));
-  return <Text color={color}>{"─".repeat(cols)}</Text>;
+  return <Text color={theme.muted}>{"─".repeat(cols)}</Text>;
 });
 
 // ---------------------------------------------------------------------------
@@ -608,6 +630,8 @@ export function Repl({
   const [streaming, setStreaming] = useState(false);
   const [totalTokenDisplay, setTotalTokenDisplay] = useState(0);
   const [statusText, setStatusText] = useState<string | null>(null);
+  const [activeThemePreference, setActiveThemePreference] = useState(getThemePreference);
+  const activeTheme = getTerminalTheme(activeThemePreference);
   const [pickerIndex, setPickerIndex] = useState(0);
   /** Full agent list while interactive /agents picker is open (filter text = `input`). */
   const [agentPickerCatalog, setAgentPickerCatalog] = useState<Agent[] | null>(null);
@@ -919,7 +943,7 @@ export function Repl({
   // ── Slash picker ──
   const filteredCommands = useMemo<SlashCommand[]>(() => {
     if (!input?.startsWith("/")) return [];
-    const query = input.slice(1).toLowerCase().trim();
+    const query = slashCommandQuery(input);
     if (query === "") return SLASH_COMMANDS;
     return SLASH_COMMANDS.filter(
       (c) => c.name.slice(1).includes(query) || c.description.toLowerCase().includes(query),
@@ -1254,6 +1278,29 @@ export function Repl({
           break;
         }
 
+        case "/theme": {
+          const arg = cmd.slice("/theme".length).trim();
+          if (!arg) {
+            pushSystemPlain(
+              `Theme: ${activeThemePreference} (${activeTheme.name})\nAvailable: ${THEME_PREFERENCES.join(", ")}\nUse: /theme <name>`,
+            );
+            break;
+          }
+          const preference = parseThemePreference(arg);
+          if (!preference) {
+            pushSystemPlain(`Unknown theme "${arg}". Choose: ${THEME_PREFERENCES.join(", ")}`);
+            break;
+          }
+          setThemePreference(preference);
+          setActiveThemePreference(preference);
+          const resolved = getTerminalTheme(preference).name;
+          setStatusText(
+            `Theme changed to ${preference}${resolved !== preference ? ` (rendering ${resolved})` : ""}.`,
+          );
+          setTimeout(() => setStatusText(null), 2000);
+          break;
+        }
+
         case "/skills":
           setStatusText("Loading skills from supervisor…");
           try {
@@ -1419,6 +1466,7 @@ export function Repl({
               `- **auth.url** = \`${s.auth?.url ?? "(not set)"}\``,
               `- **auth.idp-hint** = \`${s.auth?.idpHint ?? "(not set)"}\``,
               `- **auth.credential-storage** = \`${s.auth?.credentialStorage ?? "encrypted-file"}\``,
+              `- **ui.theme** = \`${s.ui?.theme ?? "auto"}\``,
               "\nTo edit, set **EDITOR** or run `caipe config set <key> <value>`",
             ];
             pushAssistant(lines.join("\n"));
@@ -1438,6 +1486,8 @@ export function Repl({
       streaming,
       serverUrl,
       currentAgent,
+      activeThemePreference,
+      activeTheme.name,
       switchToAgent,
       openAgentPicker,
       openSessionPicker,
@@ -1650,6 +1700,12 @@ export function Repl({
         return;
       }
       if (showPicker && filteredCommands.length > 0) {
+        if (slashInputHasArguments(raw)) {
+          setInput("");
+          setPickerIndex(0);
+          void handleSubmit(raw);
+          return;
+        }
         const selected = filteredCommands[clampPickerIndex(pickerIndex, filteredCommands.length)];
         if (selected) {
           void executeSlashCommand(selected.name);
@@ -1657,6 +1713,10 @@ export function Repl({
           setPickerIndex(0);
           return;
         }
+      }
+      if (showPicker) {
+        setInput("");
+        setPickerIndex(0);
       }
       void handleSubmit(raw);
     },
@@ -1828,6 +1888,7 @@ export function Repl({
 
   const markdownWidth = getMarkdownLayoutWidth("assistant", terminalCols);
   const terminalWidth = terminalCols;
+  const footerDirection = footerLayoutDirection(terminalCols);
 
   return (
     <Box flexDirection="column" height="100%">
@@ -1932,7 +1993,11 @@ export function Repl({
 
       <HRule />
 
-      <Box paddingX={2} justifyContent="space-between">
+      <Box
+        paddingX={2}
+        flexDirection={footerDirection}
+        justifyContent={footerDirection === "column" ? "flex-start" : "space-between"}
+      >
         <Box flexDirection="column">
           {streaming ? (
             <Text dimColor>Esc cancel · Ctrl+C stop</Text>
@@ -1942,12 +2007,13 @@ export function Repl({
             <Text dimColor>{FOOTER_HINT_IDLE}</Text>
           )}
         </Box>
-        <Text dimColor>
+        <Text dimColor wrap="truncate">
           {currentAgent.name !== "hello-world" && currentAgent.name !== "default"
-            ? `${currentAgent.name} · `
+            ? `${truncateText(currentAgent.displayName || currentAgent.name, 24)} · `
             : ""}
           {totalTokenDisplay > 0 ? `~${totalTokenDisplay} tokens · ` : ""}
           {serverHost ?? ""}
+          {activeTheme.preference !== "auto" ? ` · ${activeTheme.name}` : ""}
         </Text>
       </Box>
     </Box>

--- a/src/chat/SessionPicker.tsx
+++ b/src/chat/SessionPicker.tsx
@@ -5,6 +5,7 @@
 import { Box, Text } from "ink";
 import type React from "react";
 
+import { getTerminalTheme } from "../platform/theme.js";
 import type { SessionSummary } from "./history.js";
 import { pickerWindow } from "./picker-nav.js";
 import { PICKER_HINT_NAV } from "./shortcuts.js";
@@ -35,9 +36,16 @@ export function SessionPicker({
   filter,
   visibleRowCount = 10,
 }: SessionPickerProps): React.ReactElement {
+  const theme = getTerminalTheme();
   if (sessions.length === 0) {
     return (
-      <Box flexDirection="column" borderStyle="round" borderColor="yellow" marginX={1} paddingX={1}>
+      <Box
+        flexDirection="column"
+        borderStyle="round"
+        borderColor={theme.warning}
+        marginX={1}
+        paddingX={1}
+      >
         <Text dimColor>No sessions match {filter ? `"${filter}"` : "filter"}.</Text>
       </Box>
     );
@@ -49,9 +57,15 @@ export function SessionPicker({
   const slice = sessions.slice(start, end);
 
   return (
-    <Box flexDirection="column" borderStyle="round" borderColor="cyan" marginX={1} paddingX={1}>
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={theme.accent}
+      marginX={1}
+      paddingX={1}
+    >
       <Box marginBottom={0}>
-        <Text bold color="cyan">
+        <Text bold color={theme.accent}>
           Resume session
         </Text>
         <Text dimColor>
@@ -71,11 +85,11 @@ export function SessionPicker({
             {i > 0 ? <Text dimColor>{ROW_SEPARATOR}</Text> : null}
             <Box flexDirection="column">
               <Box>
-                <Text bold={sel} color={sel ? "cyan" : undefined} dimColor={!sel}>
+                <Text bold={sel} color={sel ? theme.accent : undefined} dimColor={!sel}>
                   {`${num} `}
                 </Text>
-                <Text color={sel ? "cyan" : undefined}>{sel ? "▶ " : "  "}</Text>
-                <Text bold={sel} color={sel ? "cyan" : "white"}>
+                <Text color={sel ? theme.accent : undefined}>{sel ? "▶ " : "  "}</Text>
+                <Text bold={sel} color={sel ? theme.accent : undefined}>
                   {shortSessionId(s.sessionId).padEnd(22)}
                 </Text>
                 <Text dimColor={!sel}> {s.agentName.padEnd(28).slice(0, 28)} </Text>
@@ -99,11 +113,11 @@ export function SessionPicker({
         <Text dimColor>{`  ↓ ${sessions.length - end} more below`}</Text>
       ) : null}
       <Box marginTop={0}>
-        <Text color="cyan" bold>
+        <Text color={theme.accent} bold>
           {`${safeIndex + 1}/${sessions.length}`}
         </Text>
         <Text dimColor> · </Text>
-        <Text bold color="white">
+        <Text bold color={theme.accent}>
           {selected ? shortSessionId(selected.sessionId) : ""}
         </Text>
         <Text dimColor> · Enter resume · Esc dismiss</Text>

--- a/src/chat/ShellApprovalPrompt.tsx
+++ b/src/chat/ShellApprovalPrompt.tsx
@@ -1,6 +1,7 @@
 import { Box, Text, useInput } from "ink";
 import type React from "react";
 
+import { getTerminalTheme } from "../platform/theme.js";
 import { type ShellApprovalRequest, shellApprovalTitle } from "./shell-hitl.js";
 
 export interface ShellApprovalPromptProps {
@@ -17,6 +18,7 @@ export function ShellApprovalPrompt({
   onApprove,
   onDeny,
 }: ShellApprovalPromptProps): React.ReactElement {
+  const theme = getTerminalTheme();
   useInput(
     (input, key) => {
       if (key.escape) {
@@ -40,19 +42,19 @@ export function ShellApprovalPrompt({
     <Box
       flexDirection="column"
       borderStyle="round"
-      borderColor="yellow"
+      borderColor={theme.warning}
       marginX={1}
       marginBottom={1}
       paddingX={1}
     >
       <Box marginBottom={1}>
-        <Text bold color="yellow">
+        <Text bold color={theme.warning}>
           {title}
         </Text>
       </Box>
       <Box marginLeft={2} marginBottom={1}>
         <Text dimColor>└ </Text>
-        <Text color="cyan">$ </Text>
+        <Text color={theme.accent}>$ </Text>
         <Text wrap="wrap">{request.cmd}</Text>
       </Box>
       <Text dimColor>y / Enter allow · n / Esc deny</Text>

--- a/src/chat/StaticHistory.tsx
+++ b/src/chat/StaticHistory.tsx
@@ -13,6 +13,7 @@ import {
   UserMessageBar,
 } from "../platform/display.js";
 import { AssistantBody, InkDiffBlock } from "../platform/markdown.js";
+import { getTerminalTheme } from "../platform/theme.js";
 import { isDiffBlock } from "./markdown-stream.js";
 
 export type StaticHistoryItem =
@@ -48,6 +49,7 @@ function StaticHistoryInner({
   markdownWidth,
   terminalWidth,
 }: StaticHistoryProps): React.ReactElement {
+  const theme = getTerminalTheme();
   return (
     <Static key={generation} items={items}>
       {(item) => {
@@ -59,7 +61,7 @@ function StaticHistoryInner({
           case "assistant":
             return (
               <Box key={item._key} paddingX={1} marginBottom={1} flexDirection="column">
-                <Text color="blue">{"⏺ "}</Text>
+                <Text color={theme.assistant}>{"⏺ "}</Text>
                 <Box paddingLeft={2} flexDirection="column">
                   {renderBody(item.text, markdownWidth)}
                 </Box>
@@ -68,14 +70,14 @@ function StaticHistoryInner({
           case "assistant-plain":
             return (
               <Box key={item._key} paddingX={1} marginBottom={1} flexDirection="row">
-                <Text color="blue">{"⏺ "}</Text>
+                <Text color={theme.assistant}>{"⏺ "}</Text>
                 <Text wrap="wrap">{item.text}</Text>
               </Box>
             );
           case "assistant-segment":
             return (
               <Box key={item._key} paddingX={1} flexDirection="row">
-                <Text color="blue">{item.lead ? "⏺ " : "  "}</Text>
+                <Text color={theme.assistant}>{item.lead ? "⏺ " : "  "}</Text>
                 {renderBody(item.text, markdownWidth, item.diff)}
               </Box>
             );
@@ -84,7 +86,7 @@ function StaticHistoryInner({
               <Text key={item._key}>{item.text}</Text>
             ) : (
               <Box key={item._key} paddingX={1}>
-                <Text color="blue">{"⏺ "}</Text>
+                <Text color={theme.assistant}>{"⏺ "}</Text>
               </Box>
             );
           case "tool-activity":
@@ -100,7 +102,7 @@ function StaticHistoryInner({
           case "tool":
             return (
               <Box key={item._key} paddingX={1} marginLeft={2}>
-                <Text color="green">
+                <Text color={theme.success}>
                   {"✓ "}
                   {item.name}
                 </Text>

--- a/src/chat/shortcuts.ts
+++ b/src/chat/shortcuts.ts
@@ -9,3 +9,8 @@ export const SHORTCUT_SLASH_COMMANDS = "/";
 export const FOOTER_HINT_IDLE = `${SHORTCUT_SLASH_COMMANDS} commands · ${SHORTCUT_AGENT_PICKER} agents · Ctrl+D exit`;
 
 export const PICKER_HINT_NAV = "↑↓ · PgUp/PgDn · Tab · Enter · Esc";
+
+/** Prevent the shortcut and context sections from colliding in narrow terminals. */
+export function footerLayoutDirection(columns: number): "column" | "row" {
+  return columns < 100 ? "column" : "row";
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { Command } from "commander";
 import pkg from "../package.json";
+import { applyThemeEnvironment } from "./platform/theme.js";
 
 // Suppress color when --no-color or NO_COLOR is set.
 // This is done early so all downstream renderers respect it.
@@ -11,6 +12,7 @@ function applyNoColor(args: string[]): void {
   }
 }
 applyNoColor(process.argv);
+applyThemeEnvironment();
 
 const program = new Command();
 

--- a/src/platform/config.ts
+++ b/src/platform/config.ts
@@ -18,6 +18,8 @@ import { join } from "node:path";
 // Types
 // ---------------------------------------------------------------------------
 
+export type ConfiguredTheme = "auto" | "dark" | "light" | "high-contrast" | "mono";
+
 export interface Settings {
   server?: {
     /** Legacy field — kept for backward compat reading old settings.json */
@@ -47,6 +49,10 @@ export interface Settings {
   kb?: {
     /** Knowledge Base RAG REST API base URL (CAIPE_KB_URL overrides) */
     url?: string;
+  };
+  ui?: {
+    /** Terminal color theme. Env override: CAIPE_THEME. */
+    theme?: ConfiguredTheme;
   };
 }
 
@@ -266,6 +272,10 @@ export function getConfiguredDefaultAgent(): string | undefined {
   const fromSettings = readSettings().agent?.default;
   if (fromSettings && fromSettings.trim() !== "") return fromSettings.trim();
   return undefined;
+}
+
+export function getConfiguredTheme(): ConfiguredTheme | undefined {
+  return readSettings().ui?.theme;
 }
 
 /**

--- a/src/platform/configcmd.ts
+++ b/src/platform/configcmd.ts
@@ -4,6 +4,7 @@
 
 import { getServerUrl, readSettings, writeSettings } from "./config.js";
 import { clearAgentConfigCache, discoverAuthIssuer } from "./discovery.js";
+import { THEME_PREFERENCES, parseThemePreference, setThemePreference } from "./theme.js";
 
 function normalizeConfigUrl(value: string, key: string): string {
   const v = value.trim().replace(/\/+$/, "");
@@ -22,7 +23,8 @@ type SupportedKey =
   | "auth.credential-storage"
   | "auth.idp-hint"
   | "agent.default"
-  | "kb.url";
+  | "kb.url"
+  | "ui.theme";
 
 const SUPPORTED_KEYS: SupportedKey[] = [
   "auth.url",
@@ -32,6 +34,7 @@ const SUPPORTED_KEYS: SupportedKey[] = [
   "auth.idp-hint",
   "agent.default",
   "kb.url",
+  "ui.theme",
 ];
 
 const CREDENTIAL_STORAGE_VALUES = ["encrypted-file", "keychain"] as const;
@@ -146,6 +149,16 @@ export async function runConfigSet(key: string, value: string): Promise<void> {
     process.stdout.write(`Set kb.url = ${url}\n`);
     return;
   }
+
+  if (key === "ui.theme") {
+    const theme = parseThemePreference(value);
+    if (!theme) {
+      process.stderr.write(`[ERROR] ui.theme must be one of: ${THEME_PREFERENCES.join(", ")}\n`);
+      process.exit(3);
+    }
+    setThemePreference(theme);
+    process.stdout.write(`Set ui.theme = ${theme}\n`);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -204,6 +217,15 @@ export async function runConfigGet(key: string, opts: { json?: boolean }): Promi
     } else {
       value = settings.kb?.url;
     }
+  } else if (key === "ui.theme") {
+    const envVal = process.env.CAIPE_THEME;
+    if (envVal) {
+      value = envVal;
+      source = "CAIPE_THEME env var";
+    } else {
+      value = settings.ui?.theme ?? "auto";
+      source = settings.ui?.theme ? "settings.json" : "default";
+    }
   }
 
   if (opts.json) {
@@ -251,6 +273,8 @@ export async function runConfigUnset(key: string): Promise<void> {
     settings.agent.default = undefined;
   } else if (key === "kb.url" && settings.kb) {
     settings.kb.url = undefined;
+  } else if (key === "ui.theme" && settings.ui) {
+    settings.ui.theme = undefined;
   }
 
   writeSettings(settings);

--- a/src/platform/display.tsx
+++ b/src/platform/display.tsx
@@ -8,16 +8,11 @@
 import { homedir } from "node:os";
 import { Box, Text } from "ink";
 import React from "react";
-
-const NO_COLOR = Boolean(process.env.NO_COLOR);
+import { ANSI_DIM, ANSI_RESET, ansiColor, getTerminalTheme } from "./theme.js";
 
 // ---------------------------------------------------------------------------
 // Session banner
 // ---------------------------------------------------------------------------
-
-const CYAN = NO_COLOR ? "" : "\x1b[96m";
-const DIM = NO_COLOR ? "" : "\x1b[2m";
-const RESET = NO_COLOR ? "" : "\x1b[0m";
 
 export interface SessionBannerInfo {
   agentName: string;
@@ -42,17 +37,21 @@ function serverHost(serverUrl: string): string {
 
 /** Compact startup context, inspired by modern coding-agent CLIs. */
 export function formatSessionBanner(info: SessionBannerInfo): string {
+  const theme = getTerminalTheme();
+  const accent = ansiColor(theme.accent);
+  const dim = theme.colorEnabled ? ANSI_DIM : "";
+  const reset = theme.colorEnabled ? ANSI_RESET : "";
   const displayAgent =
     info.agentDisplayName === info.agentName
       ? info.agentName
       : `${info.agentDisplayName} (${info.agentName})`;
   const resume = info.resumed ? " · resumed" : "";
   return [
-    `${CYAN}CAIPE${RESET}${resume}`,
-    `  ${DIM}agent${RESET}     ${displayAgent}`,
-    `  ${DIM}workspace${RESET} ${compactHome(info.workingDir)}`,
-    `  ${DIM}server${RESET}    ${serverHost(info.serverUrl)}`,
-    `  ${DIM}hint${RESET}      / commands · Ctrl+O agents`,
+    `${accent}CAIPE${reset}${resume}`,
+    `  ${dim}agent${reset}     ${displayAgent}`,
+    `  ${dim}workspace${reset} ${compactHome(info.workingDir)}`,
+    `  ${dim}server${reset}    ${serverHost(info.serverUrl)}`,
+    `  ${dim}hint${reset}      / commands · Ctrl+O agents`,
     "",
   ].join("\n");
 }
@@ -83,9 +82,10 @@ export interface SpinnerProps {
  * Animated Ink spinner component using CAIPE's unique beacon frames.
  * Falls back to ASCII when NO_COLOR is set.
  */
-export function Spinner({ label, color = "cyan" }: SpinnerProps): React.ReactElement {
+export function Spinner({ label, color }: SpinnerProps): React.ReactElement {
   const { useState, useEffect } = React;
-  const frames = NO_COLOR ? SPINNER_PLAIN : CAIPE_SPINNER_FRAMES;
+  const theme = getTerminalTheme();
+  const frames = theme.colorEnabled ? CAIPE_SPINNER_FRAMES : SPINNER_PLAIN;
   const [frame, setFrame] = useState(0);
 
   useEffect(() => {
@@ -97,7 +97,7 @@ export function Spinner({ label, color = "cyan" }: SpinnerProps): React.ReactEle
 
   return (
     <Box>
-      <Text color={NO_COLOR ? undefined : color}>{frames[frame]} </Text>
+      <Text color={color ?? theme.accent}>{frames[frame]} </Text>
       <Text>{label}</Text>
     </Box>
   );
@@ -127,7 +127,8 @@ export function StreamingSpinner({
   tokenCount,
 }: StreamingSpinnerProps): React.ReactElement {
   const { useState, useEffect } = React;
-  const frames = NO_COLOR ? SPINNER_PLAIN : CAIPE_SPINNER_FRAMES;
+  const theme = getTerminalTheme();
+  const frames = theme.colorEnabled ? CAIPE_SPINNER_FRAMES : SPINNER_PLAIN;
   const [frame, setFrame] = useState(0);
 
   useEffect(() => {
@@ -137,8 +138,8 @@ export function StreamingSpinner({
 
   return (
     <Box>
-      <Text color={NO_COLOR ? undefined : "blue"}>{frames[frame]} </Text>
-      <Text color={NO_COLOR ? undefined : "blue"}>{label}… </Text>
+      <Text color={theme.info}>{frames[frame]} </Text>
+      <Text color={theme.info}>{label}… </Text>
       <Text dimColor>
         ({elapsed}s{tokenCount !== undefined && tokenCount > 0 ? ` · ~${tokenCount} tokens` : ""})
       </Text>
@@ -178,12 +179,13 @@ export interface UserMessageBarProps {
 
 /** Full-width dim band for the user's prompt (Claude Code–style). */
 export function UserMessageBar({ text, width }: UserMessageBarProps): React.ReactElement {
+  const theme = getTerminalTheme();
   return (
     <Box width={width} marginBottom={1}>
       {/* ink 5 has no Box-level background; the band tint lives on the Text nodes. */}
       <Box width={width} paddingX={1}>
-        <Text backgroundColor={NO_COLOR ? undefined : "gray"} wrap="wrap">
-          <Text bold={!NO_COLOR}>{"> "}</Text>
+        <Text backgroundColor={theme.userBackground} wrap="wrap">
+          <Text bold={theme.colorEnabled}>{"> "}</Text>
           <Text>{text}</Text>
         </Text>
       </Box>
@@ -236,7 +238,8 @@ export function ToolActivityPanel({
   omittedCount = 0,
 }: ToolActivityPanelProps): React.ReactElement {
   const { useState, useEffect } = React;
-  const frames = NO_COLOR ? SPINNER_PLAIN : CAIPE_SPINNER_FRAMES;
+  const theme = getTerminalTheme();
+  const frames = theme.colorEnabled ? CAIPE_SPINNER_FRAMES : SPINNER_PLAIN;
   const [frame, setFrame] = useState(0);
 
   useEffect(() => {
@@ -265,16 +268,13 @@ export function ToolActivityPanel({
     <Box flexDirection="column" marginBottom={1}>
       <Box paddingX={1}>
         {phase === "running" && animatedWaitEnabled() ? (
-          <Text color={NO_COLOR ? undefined : "yellow"}>{frames[frame]} </Text>
+          <Text color={theme.warning}>{frames[frame]} </Text>
         ) : phase === "running" ? (
-          <Text color={NO_COLOR ? undefined : "yellow"}>● </Text>
+          <Text color={theme.warning}>● </Text>
         ) : (
           <Text dimColor>● </Text>
         )}
-        <Text
-          color={phase === "running" && !NO_COLOR ? "yellow" : undefined}
-          dimColor={phase === "done"}
-        >
+        <Text color={phase === "running" ? theme.warning : undefined} dimColor={phase === "done"}>
           {summary}
         </Text>
       </Box>
@@ -296,12 +296,12 @@ export function ToolActivityPanel({
               {branch}{" "}
               {isUpdate ? (
                 <>
-                  <Text color={NO_COLOR ? undefined : "green"}>● </Text>
-                  <Text color={NO_COLOR ? undefined : "green"}>{label}</Text>
+                  <Text color={theme.success}>● </Text>
+                  <Text color={theme.success}>{label}</Text>
                 </>
               ) : (
                 <>
-                  $ <Text color={NO_COLOR ? undefined : "cyan"}>{label}</Text>
+                  $ <Text color={theme.accent}>{label}</Text>
                 </>
               )}
             </Text>
@@ -343,7 +343,10 @@ export function StreamWaitLine({
   tokenCount,
 }: StreamWaitLineProps): React.ReactElement {
   const { useState, useEffect } = React;
-  const frames = NO_COLOR ? SPINNER_PLAIN : ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+  const theme = getTerminalTheme();
+  const frames = theme.colorEnabled
+    ? ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+    : SPINNER_PLAIN;
   const [frame, setFrame] = useState(0);
 
   useEffect(() => {
@@ -356,11 +359,11 @@ export function StreamWaitLine({
 
   return (
     <Box>
-      <Text color={NO_COLOR ? undefined : "magenta"}>* </Text>
+      <Text color={theme.assistant}>* </Text>
       {animatedWaitEnabled() ? (
-        <Text color={NO_COLOR ? undefined : "magenta"}>{frames[frame]} </Text>
+        <Text color={theme.assistant}>{frames[frame]} </Text>
       ) : (
-        <Text color={NO_COLOR ? undefined : "magenta"}>● </Text>
+        <Text color={theme.assistant}>● </Text>
       )}
       <Text>{label}… </Text>
       <Text dimColor>
@@ -375,7 +378,8 @@ export function StreamWaitLine({
  */
 export function ToolRunStatus({ runs, streamElapsed }: ToolRunStatusProps): React.ReactElement {
   const { useState, useEffect } = React;
-  const frames = NO_COLOR ? SPINNER_PLAIN : CAIPE_SPINNER_FRAMES;
+  const theme = getTerminalTheme();
+  const frames = theme.colorEnabled ? CAIPE_SPINNER_FRAMES : SPINNER_PLAIN;
   const [frame, setFrame] = useState(0);
 
   useEffect(() => {
@@ -399,8 +403,8 @@ export function ToolRunStatus({ runs, streamElapsed }: ToolRunStatusProps): Reac
   return (
     <Box flexDirection="column">
       <Box>
-        <Text color={NO_COLOR ? undefined : "yellow"}>{frames[frame]} </Text>
-        <Text color={NO_COLOR ? undefined : "yellow"}>{label} </Text>
+        <Text color={theme.warning}>{frames[frame]} </Text>
+        <Text color={theme.warning}>{label} </Text>
         <Text dimColor>({streamElapsed}s)</Text>
       </Box>
     </Box>
@@ -420,6 +424,7 @@ export interface ProgressBarProps {
 }
 
 export function ProgressBar({ progress, width = 30, label }: ProgressBarProps): React.ReactElement {
+  const theme = getTerminalTheme();
   const filled = Math.round(Math.max(0, Math.min(1, progress)) * width);
   const empty = width - filled;
   const bar = "█".repeat(filled) + "░".repeat(empty);
@@ -427,7 +432,7 @@ export function ProgressBar({ progress, width = 30, label }: ProgressBarProps): 
 
   return (
     <Box>
-      <Text color={NO_COLOR ? undefined : "cyan"}>[{bar}]</Text>
+      <Text color={theme.accent}>[{bar}]</Text>
       <Text> {pct}</Text>
       {label !== undefined && <Text dimColor> {label}</Text>}
     </Box>
@@ -445,8 +450,9 @@ export function ProgressBar({ progress, width = 30, label }: ProgressBarProps): 
  *   unavailable → red ●
  */
 export function statusDot(available: boolean | "degraded"): string {
-  if (NO_COLOR) return available ? "[ok]" : "[x]";
-  if (available === true) return "\x1b[32m●\x1b[0m";
-  if (available === "degraded") return "\x1b[33m●\x1b[0m";
-  return "\x1b[31m●\x1b[0m";
+  const theme = getTerminalTheme();
+  if (!theme.colorEnabled) return available ? "[ok]" : "[x]";
+  const color =
+    available === true ? theme.success : available === "degraded" ? theme.warning : theme.danger;
+  return `${ansiColor(color)}●${ANSI_RESET}`;
 }

--- a/src/platform/setup.tsx
+++ b/src/platform/setup.tsx
@@ -15,6 +15,7 @@ import { Box, Text, useApp, useInput } from "ink";
 import { render } from "ink";
 import React, { useState } from "react";
 import { readSettings, writeSettings } from "./config.js";
+import { getTerminalTheme } from "./theme.js";
 
 // ---------------------------------------------------------------------------
 // Ink wizard component
@@ -25,6 +26,7 @@ interface WizardProps {
 }
 
 function SetupWizard({ onDone }: WizardProps): React.ReactElement {
+  const theme = getTerminalTheme();
   const { exit } = useApp();
   const [input, setInput] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -61,19 +63,19 @@ function SetupWizard({ onDone }: WizardProps): React.ReactElement {
 
   return (
     <Box flexDirection="column" marginY={1}>
-      <Text bold color="cyan">
+      <Text bold color={theme.accent}>
         Welcome to CAIPE CLI — First-time Setup
       </Text>
       <Box marginTop={1}>
         <Text>Enter your caipe-ui URL (e.g. https://caipe.your-company.com): </Text>
       </Box>
       <Box>
-        <Text color="green">{input}</Text>
-        <Text color="gray">█</Text>
+        <Text color={theme.prompt}>{input}</Text>
+        <Text color={theme.muted}>█</Text>
       </Box>
       {error !== null && (
         <Box marginTop={1}>
-          <Text color="red">{error}</Text>
+          <Text color={theme.danger}>{error}</Text>
         </Box>
       )}
       <Box marginTop={1}>

--- a/src/platform/theme.ts
+++ b/src/platform/theme.ts
@@ -1,0 +1,147 @@
+import { type ConfiguredTheme, getConfiguredTheme, readSettings, writeSettings } from "./config.js";
+
+export const THEME_PREFERENCES = ["auto", "dark", "light", "high-contrast", "mono"] as const;
+export type ThemePreference = ConfiguredTheme;
+export type ResolvedThemeName = Exclude<ThemePreference, "auto">;
+
+export interface TerminalTheme {
+  preference: ThemePreference;
+  name: ResolvedThemeName;
+  colorEnabled: boolean;
+  accent?: string;
+  info?: string;
+  success?: string;
+  warning?: string;
+  danger?: string;
+  prompt?: string;
+  assistant?: string;
+  muted?: string;
+  selectedBackground?: string;
+  selectedForeground?: string;
+  userBackground?: string;
+}
+
+const THEMES: Record<ResolvedThemeName, Omit<TerminalTheme, "preference" | "name">> = {
+  dark: {
+    colorEnabled: true,
+    accent: "cyan",
+    info: "blue",
+    success: "green",
+    warning: "yellow",
+    danger: "red",
+    prompt: "green",
+    assistant: "blue",
+    muted: "gray",
+    selectedBackground: "blue",
+    selectedForeground: "white",
+    userBackground: "gray",
+  },
+  light: {
+    colorEnabled: true,
+    accent: "blue",
+    info: "magenta",
+    success: "green",
+    warning: "yellow",
+    danger: "red",
+    prompt: "blue",
+    assistant: "magenta",
+    muted: "gray",
+    selectedBackground: "cyan",
+    selectedForeground: "black",
+    userBackground: "white",
+  },
+  "high-contrast": {
+    colorEnabled: true,
+    accent: "yellow",
+    info: "cyan",
+    success: "greenBright",
+    warning: "yellowBright",
+    danger: "redBright",
+    prompt: "yellowBright",
+    assistant: "cyanBright",
+    muted: "white",
+    selectedBackground: "yellowBright",
+    selectedForeground: "black",
+    userBackground: "gray",
+  },
+  mono: { colorEnabled: false },
+};
+
+function isThemePreference(value: string | undefined): value is ThemePreference {
+  return THEME_PREFERENCES.includes(value as ThemePreference);
+}
+
+export function getThemePreference(): ThemePreference {
+  const env = process.env.CAIPE_THEME?.trim().toLowerCase();
+  if (isThemePreference(env)) return env;
+  return getConfiguredTheme() ?? "auto";
+}
+
+export function resolveAutoTheme(colorFgBg = process.env.COLORFGBG): ResolvedThemeName {
+  const background = colorFgBg?.split(";").at(-1);
+  if (background && Number.parseInt(background, 10) >= 7) return "light";
+  return "dark";
+}
+
+export function getTerminalTheme(preference = getThemePreference()): TerminalTheme {
+  const name: ResolvedThemeName =
+    process.env.NO_COLOR || preference === "mono"
+      ? "mono"
+      : preference === "auto"
+        ? resolveAutoTheme()
+        : preference;
+  return { preference, name, ...THEMES[name] };
+}
+
+export function setThemePreference(preference: ThemePreference): void {
+  const settings = readSettings();
+  settings.ui = { ...settings.ui, theme: preference };
+  writeSettings(settings);
+  applyThemeEnvironment(preference);
+}
+
+export function parseThemePreference(value: string): ThemePreference | undefined {
+  const normalized = value.trim().toLowerCase();
+  return isThemePreference(normalized) ? normalized : undefined;
+}
+
+/** Make non-Ink renderers honor the mono theme without overriding user NO_COLOR. */
+export function applyThemeEnvironment(preference = getThemePreference()): void {
+  if (preference === "mono") {
+    if (!process.env.NO_COLOR) process.env.CAIPE_THEME_SET_NO_COLOR = "1";
+    process.env.NO_COLOR = "1";
+    process.env.FORCE_COLOR = "0";
+    return;
+  }
+  if (process.env.CAIPE_THEME_SET_NO_COLOR === "1") {
+    delete process.env.NO_COLOR;
+    delete process.env.CAIPE_THEME_SET_NO_COLOR;
+    delete process.env.FORCE_COLOR;
+  }
+}
+
+const ANSI_CODES: Record<string, number> = {
+  black: 30,
+  red: 31,
+  green: 32,
+  yellow: 33,
+  blue: 34,
+  magenta: 35,
+  cyan: 36,
+  white: 37,
+  gray: 90,
+  redBright: 91,
+  greenBright: 92,
+  yellowBright: 93,
+  blueBright: 94,
+  magentaBright: 95,
+  cyanBright: 96,
+};
+
+export function ansiColor(color?: string): string {
+  const code = color ? ANSI_CODES[color] : undefined;
+  return code ? `\x1b[${code}m` : "";
+}
+
+export const ANSI_RESET = "\x1b[0m";
+export const ANSI_DIM = "\x1b[2m";

--- a/tests/agents.commands.test.ts
+++ b/tests/agents.commands.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { formatAgentListPlain } from "../src/agents/commands.js";
+import type { Agent } from "../src/agents/types.js";
+
+describe("formatAgentListPlain", () => {
+  it("puts readable display names before internal ids without fixed-width overflow", () => {
+    const agents: Agent[] = [
+      {
+        name: "agent-primary-with-a-long-internal-id",
+        displayName: "Primary Agent",
+        description: "Example",
+        endpoint: "",
+        protocols: ["agui"],
+        available: true,
+        domain: "general",
+      },
+    ];
+
+    const output = formatAgentListPlain(agents);
+    expect(output).toContain("Accessible agents (1)");
+    expect(output).toContain("✓ Primary Agent");
+    expect(output).toContain("  agent-primary-with-a-long-internal-id · general · agui");
+  });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -87,6 +87,12 @@ describe("settings read/write", () => {
     expect(s.agent?.default).toBe("agent-sre");
   });
 
+  it("round-trips ui.theme", () => {
+    writeSettings({ ui: { theme: "high-contrast" } });
+    const s = readSettings();
+    expect(s.ui?.theme).toBe("high-contrast");
+  });
+
   it("handles corrupted settings file gracefully", () => {
     const { writeFileSync, mkdirSync } = require("node:fs") as typeof import("fs");
     mkdirSync(require("node:path").dirname(settingsJsonPath()), { recursive: true });

--- a/tests/shortcuts.test.ts
+++ b/tests/shortcuts.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { footerLayoutDirection } from "../src/chat/shortcuts.js";
+
+describe("footerLayoutDirection", () => {
+  it("stacks context below shortcuts in narrow terminals", () => {
+    expect(footerLayoutDirection(80)).toBe("column");
+    expect(footerLayoutDirection(99)).toBe("column");
+  });
+
+  it("uses one row when both sections fit", () => {
+    expect(footerLayoutDirection(100)).toBe("row");
+    expect(footerLayoutDirection(160)).toBe("row");
+  });
+});

--- a/tests/slash-input.test.ts
+++ b/tests/slash-input.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { slashCommandQuery, slashInputHasArguments } from "../src/chat/Repl.js";
+
+describe("slash command input", () => {
+  it("filters by command name while preserving arguments for execution", () => {
+    expect(slashCommandQuery("/theme high-contrast")).toBe("theme");
+    expect(slashInputHasArguments("/theme high-contrast")).toBe(true);
+  });
+
+  it("distinguishes command completion from argument entry", () => {
+    expect(slashCommandQuery("/sta")).toBe("sta");
+    expect(slashInputHasArguments("/sta")).toBe(false);
+    expect(slashInputHasArguments("/theme ")).toBe(false);
+  });
+});

--- a/tests/theme.test.ts
+++ b/tests/theme.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { getTerminalTheme, parseThemePreference, resolveAutoTheme } from "../src/platform/theme.js";
+
+describe("terminal themes", () => {
+  const env = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...env };
+  });
+
+  it("detects light and dark terminal backgrounds", () => {
+    expect(resolveAutoTheme("15;0")).toBe("dark");
+    expect(resolveAutoTheme("0;15")).toBe("light");
+    expect(resolveAutoTheme(undefined)).toBe("dark");
+  });
+
+  it("provides distinct semantic palettes", () => {
+    delete process.env.NO_COLOR;
+    const dark = getTerminalTheme("dark");
+    const light = getTerminalTheme("light");
+    const contrast = getTerminalTheme("high-contrast");
+
+    expect(dark.accent).toBe("cyan");
+    expect(light.accent).toBe("blue");
+    expect(contrast.accent).toBe("yellow");
+    expect(new Set([dark.assistant, light.assistant, contrast.assistant]).size).toBe(3);
+  });
+
+  it("lets NO_COLOR override configured themes", () => {
+    process.env.NO_COLOR = "1";
+    expect(getTerminalTheme("high-contrast").name).toBe("mono");
+    expect(getTerminalTheme("high-contrast").colorEnabled).toBe(false);
+  });
+
+  it("validates theme names", () => {
+    expect(parseThemePreference(" LIGHT ")).toBe("light");
+    expect(parseThemePreference("neon")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- add `auto`, `dark`, `light`, `high-contrast`, and `mono` terminal themes with semantic UI colors
- add live `/theme` switching plus persistent `ui.theme` and `CAIPE_THEME` configuration
- improve agent-list readability, narrow-terminal footer layout, and slash-command argument handling
- apply the same theme roles across chat, pickers, activity indicators, setup, and history UI

## End-user validation

Authenticated to Grid through the normal system-browser OAuth flow and exercised the CLI in a real 80-column TTY with Tome Agent. Verified agent discovery, `/status`, live high-contrast-to-mono switching, responsive footer layout, and command-picker dismissal after `/theme mono`.

The persisted theme was restored to `auto` after testing.

## Testing

- `bun run lint` (passes with 18 pre-existing warnings)
- `bunx tsc --noEmit`
- `bun run test` (226 tests)
- `bun build src/index.ts --outdir /tmp/caipe-cli-theme-build --target node --external keytar --external fsevents`
- authenticated Grid/Tome Agent smoke test in a real TTY

## Stack

- Base: #41
- This PR contains only the theme and usability follow-up.
