### PR TITLE
feat(cli): add verified auto-updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,17 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Verify package version matches tag
+        shell: bash
+        run: |
+          tag="${GITHUB_REF_NAME#caipe/}"
+          release_version="${tag#v}"
+          package_version="$(node -p "require('./package.json').version")"
+          test "$package_version" = "$release_version" || {
+            echo "package.json version $package_version does not match tag $release_version" >&2
+            exit 1
+          }
+
       - name: Type check
         run: bun tsc --noEmit
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ until the first multi-architecture release is available.
 
 ### Updates
 
-Interactive chat checks GitHub Releases at most once every 24 hours and prints
-one notification when a newer verified release is available. Update manually:
+Interactive chat checks GitHub Releases at most once every 24 hours. Known
+binary installs update automatically; other install types receive one
+notification per release. Update manually:
 
 ```bash
 caipe update --check    # inspect only
@@ -64,10 +65,11 @@ caipe update            # download, verify, smoke-test, and install
 
 Downloaded binaries must match `caipe-checksums.txt` and pass `--version`
 before atomically replacing the installed binary. npm-managed installations
-delegate an explicit update to npm. Automatic binary installation is opt-in:
+delegate an explicit update to npm. Verified binary updates install
+automatically by default:
 
 ```bash
-caipe config set updates.mode auto    # notify (default), auto, or off
+caipe config set updates.mode notify  # auto (default), notify, or off
 ```
 
 Source or unknown launchers fall back to a notification and an actionable
@@ -188,7 +190,7 @@ caipe config set auth.idp-hint duo-sso
 | `CAIPE_SERVER_URL` | BFF base URL (agents, chat stream) |
 | `CAIPE_AUTH_URL` | OAuth / discovery base (login) |
 | `CAIPE_DEFAULT_AGENT` | Default dynamic agent id (overrides `agent.default` in settings) |
-| `CAIPE_UPDATE_MODE` | CLI update behavior: `notify` (default), `auto`, or `off` |
+| `CAIPE_UPDATE_MODE` | CLI update behavior: `auto` (default), `notify`, or `off` |
 | `CAIPE_NO_UPDATE_CHECK` | Set to `1` to skip the startup update check |
 | `CAIPE_AUTH_REALM` | Keycloak realm name for IdP heuristics (default `caipe`) |
 | `CAIPE_PLAIN_TERMINAL` | Set to `1` to disable rich markdown, alt screen, and inline images |
@@ -293,7 +295,7 @@ Shared flags on `caipe kb`: `--kb-url`, `--token`, `--tenant-id` (or `CAIPE_TENA
 | `agent.default` | Default dynamic agent id for `caipe chat` when `--agent` is omitted |
 | `auth.idp-hint` | Skip Keycloak login chooser (`kc_idp_hint`) |
 | `kb.url` | Knowledge Base RAG REST API base URL |
-| `updates.mode` | Daily CLI update behavior: `notify`, `auto`, or `off` |
+| `updates.mode` | Daily CLI update behavior: `auto` (default), `notify`, or `off` |
 | `auth.apiKey` | Static API key (headless alternative) |
 | `auth.credential-storage` | `encrypted-file` (default) or `keychain` |
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,27 @@ The npm package and downloadable release binaries are not published yet. Do
 not use `npm install caipe`, `npx github:cnoe-io/caipe-cli`, or `install.sh`
 until the first multi-architecture release is available.
 
+### Updates
+
+Interactive chat checks GitHub Releases at most once every 24 hours and prints
+one notification when a newer verified release is available. Update manually:
+
+```bash
+caipe update --check    # inspect only
+caipe update            # download, verify, smoke-test, and install
+```
+
+Downloaded binaries must match `caipe-checksums.txt` and pass `--version`
+before atomically replacing the installed binary. npm-managed installations
+delegate an explicit update to npm. Automatic binary installation is opt-in:
+
+```bash
+caipe config set updates.mode auto    # notify (default), auto, or off
+```
+
+Source or unknown launchers fall back to a notification and an actionable
+manual update command. Set `CAIPE_NO_UPDATE_CHECK=1` for a one-off invocation.
+
 ---
 
 ## Developer guide
@@ -167,6 +188,8 @@ caipe config set auth.idp-hint duo-sso
 | `CAIPE_SERVER_URL` | BFF base URL (agents, chat stream) |
 | `CAIPE_AUTH_URL` | OAuth / discovery base (login) |
 | `CAIPE_DEFAULT_AGENT` | Default dynamic agent id (overrides `agent.default` in settings) |
+| `CAIPE_UPDATE_MODE` | CLI update behavior: `notify` (default), `auto`, or `off` |
+| `CAIPE_NO_UPDATE_CHECK` | Set to `1` to skip the startup update check |
 | `CAIPE_AUTH_REALM` | Keycloak realm name for IdP heuristics (default `caipe`) |
 | `CAIPE_PLAIN_TERMINAL` | Set to `1` to disable rich markdown, alt screen, and inline images |
 | `CAIPE_NO_ALT_SCREEN` | Set to `1` to keep chat in the normal scrollback buffer |
@@ -270,10 +293,11 @@ Shared flags on `caipe kb`: `--kb-url`, `--token`, `--tenant-id` (or `CAIPE_TENA
 | `agent.default` | Default dynamic agent id for `caipe chat` when `--agent` is omitted |
 | `auth.idp-hint` | Skip Keycloak login chooser (`kc_idp_hint`) |
 | `kb.url` | Knowledge Base RAG REST API base URL |
-
-**Rich terminal output (interactive chat):** Markdown is rendered with **react-markdown** + **remark-gfm** as native Ink components (no ANSI markdown strings). Diffs use Ink colors. Block streaming caches completed sections in `<Static>`; the active tail updates in place. Tool runs show in the footer. Chat uses the **alternate screen** unless `CAIPE_NO_ALT_SCREEN=1` or `CAIPE_PLAIN_TERMINAL=1`. Legacy plain streaming: `CAIPE_STREAM_PLAIN=1`.
+| `updates.mode` | Daily CLI update behavior: `notify`, `auto`, or `off` |
 | `auth.apiKey` | Static API key (headless alternative) |
 | `auth.credential-storage` | `encrypted-file` (default) or `keychain` |
+
+**Rich terminal output (interactive chat):** Markdown is rendered with **react-markdown** + **remark-gfm** as native Ink components (no ANSI markdown strings). Diffs use Ink colors. Block streaming caches completed sections in `<Static>`; the active tail updates in place. Tool runs show in the footer. Chat uses the **alternate screen** unless `CAIPE_NO_ALT_SCREEN=1` or `CAIPE_PLAIN_TERMINAL=1`. Legacy plain streaming: `CAIPE_STREAM_PLAIN=1`.
 
 **Default credentials:** encrypted file at `~/.config/caipe/credentials.enc` (AES-256-GCM, machine-derived key). No Keychain prompts unless you opt into `keychain`.
 
@@ -289,6 +313,7 @@ Shared flags on `caipe kb`: `--kb-url`, `--token`, `--tenant-id` (or `CAIPE_TENA
 | `caipe agents list\|info` | Server agents |
 | `caipe kb …` | KB query, read chunks, ingest, jobs, RBAC (`user info`) — JSON only |
 | `caipe skills list\|install\|preview\|update` | Skill catalog |
+| `caipe update [--check]` | Check for or install a verified CLI release |
 | `caipe memory` | Project memory files |
 | `caipe commit` | DCO-aware commit helper |
 

--- a/bin/caipe.cjs
+++ b/bin/caipe.cjs
@@ -27,7 +27,7 @@ function die(msg) {
   process.exit(1);
 }
 
-/** @typedef {{ kind: "exec", bin: string, binArgs: string[] } | { kind: "node", script: string, extraArgs?: string[] }} LaunchSpec */
+/** @typedef {{ kind: "exec", bin: string, binArgs: string[], env?: Record<string, string> } | { kind: "node", script: string, extraArgs?: string[], env?: Record<string, string> }} LaunchSpec */
 
 /** @returns {LaunchSpec[]} */
 function launchChain() {
@@ -47,7 +47,18 @@ function launchChain() {
       continue;
     }
     if (fs.existsSync(binPath)) {
-      packagedBinary = { kind: "exec", bin: binPath, binArgs: args };
+      const packageParent = path.dirname(root);
+      const npmManaged =
+        path.basename(packageParent) === "node_modules" &&
+        path.basename(path.dirname(packageParent)) === "lib";
+      packagedBinary = {
+        kind: "exec",
+        bin: binPath,
+        binArgs: args,
+        env: npmManaged
+          ? { CAIPE_INSTALL_METHOD: "npm" }
+          : { CAIPE_INSTALL_METHOD: "binary", CAIPE_BINARY_PATH: binPath },
+      };
       chain.push(packagedBinary);
       break;
     }
@@ -55,7 +66,12 @@ function launchChain() {
 
   const bundleCjs = path.join(root, "dist", "bundle.cjs");
   if (fs.existsSync(bundleCjs)) {
-    chain.push({ kind: "node", script: bundleCjs, extraArgs: args });
+    chain.push({
+      kind: "node",
+      script: bundleCjs,
+      extraArgs: args,
+      env: { CAIPE_INSTALL_METHOD: "source" },
+    });
   }
 
   let tsxCli;
@@ -66,12 +82,22 @@ function launchChain() {
   }
   const entry = path.join(root, "src", "index.ts");
   if (tsxCli && fs.existsSync(entry)) {
-    chain.unshift({ kind: "node", script: tsxCli, extraArgs: [entry, ...args] });
+    chain.unshift({
+      kind: "node",
+      script: tsxCli,
+      extraArgs: [entry, ...args],
+      env: { CAIPE_INSTALL_METHOD: "source" },
+    });
   }
 
   const local = path.join(root, "dist", "caipe");
   if (fs.existsSync(local)) {
-    chain.push({ kind: "exec", bin: local, binArgs: args });
+    chain.push({
+      kind: "exec",
+      bin: local,
+      binArgs: args,
+      env: { CAIPE_INSTALL_METHOD: "binary", CAIPE_BINARY_PATH: local },
+    });
   }
 
   if (preferCompiled && chain.length > 1) {
@@ -93,12 +119,13 @@ function launchChain() {
 }
 
 function spawnSpec(spec) {
+  const env = spec.env ? { ...process.env, ...spec.env } : process.env;
   if (spec.kind === "exec") {
-    return spawnSync(spec.bin, spec.binArgs, { stdio: "inherit" });
+    return spawnSync(spec.bin, spec.binArgs, { stdio: "inherit", env });
   }
   const nodeArgs = [spec.script];
   if (spec.extraArgs?.length) nodeArgs.push(...spec.extraArgs);
-  return spawnSync(process.execPath, nodeArgs, { stdio: "inherit" });
+  return spawnSync(process.execPath, nodeArgs, { stdio: "inherit", env });
 }
 
 function wasSigKill(result) {

--- a/install.sh
+++ b/install.sh
@@ -164,7 +164,12 @@ if (!fs.existsSync(bin)) {
   process.stderr.write("[caipe] Missing " + bin + ". Re-run install.sh.\n");
   process.exit(1);
 }
-const r = spawnSync(bin, args, { stdio: "inherit" });
+const env = {
+  ...process.env,
+  CAIPE_INSTALL_METHOD: "binary",
+  CAIPE_BINARY_PATH: bin,
+};
+const r = spawnSync(bin, args, { stdio: "inherit", env });
 process.exit(r.status ?? (r.signal ? 128 : 1));
 LAUNCHER_EOF
   chmod +x "${LAUNCHER}"

--- a/src/chat/Repl.tsx
+++ b/src/chat/Repl.tsx
@@ -1393,7 +1393,7 @@ export function Repl({
               `- **auth.url** = \`${s.auth?.url ?? "(not set)"}\``,
               `- **auth.idp-hint** = \`${s.auth?.idpHint ?? "(not set)"}\``,
               `- **auth.credential-storage** = \`${s.auth?.credentialStorage ?? "encrypted-file"}\``,
-              `- **updates.mode** = \`${s.updates?.mode ?? "notify"}\``,
+              `- **updates.mode** = \`${s.updates?.mode ?? "auto"}\``,
               "\nTo edit, set **EDITOR** or run `caipe config set <key> <value>`",
             ];
             pushAssistant(lines.join("\n"));

--- a/src/chat/Repl.tsx
+++ b/src/chat/Repl.tsx
@@ -1393,6 +1393,7 @@ export function Repl({
               `- **auth.url** = \`${s.auth?.url ?? "(not set)"}\``,
               `- **auth.idp-hint** = \`${s.auth?.idpHint ?? "(not set)"}\``,
               `- **auth.credential-storage** = \`${s.auth?.credentialStorage ?? "encrypted-file"}\``,
+              `- **updates.mode** = \`${s.updates?.mode ?? "notify"}\``,
               "\nTo edit, set **EDITOR** or run `caipe config set <key> <value>`",
             ];
             pushAssistant(lines.join("\n"));

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,15 @@ applyNoColor(process.argv);
 
 const program = new Command();
 
+async function runStartupUpdateCheck(): Promise<void> {
+  try {
+    const { maybeRunStartupUpdate } = await import("./update/startup.js");
+    await maybeRunStartupUpdate(pkg.version);
+  } catch {
+    // Update checks must never prevent the requested CLI command from running.
+  }
+}
+
 program
   .name("caipe")
   .description("Custom Agents, workflows and more... caipe.io")
@@ -46,6 +55,7 @@ const chatCmd = program
     "Multi-turn headless mode; reads newline-delimited turns from stdin",
   )
   .action(async (opts: Record<string, unknown>) => {
+    await runStartupUpdateCheck();
     const { runChat } = await import("./chat/runner.js");
     await runChat(opts, program.opts());
   });
@@ -123,6 +133,27 @@ configCmd
   .action(async (key: string, value: string) => {
     const { runConfigSet } = await import("./platform/configcmd.js");
     await runConfigSet(key, value);
+  });
+
+// ---------------------------------------------------------------------------
+// caipe update
+// ---------------------------------------------------------------------------
+program
+  .command("update")
+  .description("Check for and install a verified caipe CLI release")
+  .option("--check", "Check for an update without installing it")
+  .option("--force", "Reinstall the latest release even when versions match")
+  .option("--json", "Output JSON")
+  .action(async (opts: Record<string, unknown>) => {
+    const { runUpdate } = await import("./update/commands.js");
+    await runUpdate(
+      {
+        check: opts.check === true,
+        force: opts.force === true,
+        json: opts.json === true || program.opts().json === true,
+      },
+      pkg.version,
+    );
   });
 
 configCmd
@@ -405,6 +436,7 @@ program
 // Default action: open chat REPL when invoked with no subcommand
 // ---------------------------------------------------------------------------
 program.action(async () => {
+  await runStartupUpdateCheck();
   const { runChat } = await import("./chat/runner.js");
   await runChat({}, program.opts());
 });

--- a/src/platform/config.ts
+++ b/src/platform/config.ts
@@ -51,7 +51,7 @@ export interface Settings {
     url?: string;
   };
   updates?: {
-    /** Daily CLI update behavior. Env override: CAIPE_UPDATE_MODE. */
+    /** Daily CLI update behavior. Default: auto. Env override: CAIPE_UPDATE_MODE. */
     mode?: UpdateMode;
   };
 }
@@ -274,11 +274,11 @@ export function getConfiguredDefaultAgent(): string | undefined {
   return undefined;
 }
 
-/** Resolve update behavior. Priority: CAIPE_UPDATE_MODE → settings → notify. */
+/** Resolve update behavior. Priority: CAIPE_UPDATE_MODE → settings → auto. */
 export function getUpdateMode(): UpdateMode {
   const env = process.env.CAIPE_UPDATE_MODE?.trim().toLowerCase();
   if (env === "notify" || env === "auto" || env === "off") return env;
-  return readSettings().updates?.mode ?? "notify";
+  return readSettings().updates?.mode ?? "auto";
 }
 
 /**

--- a/src/platform/config.ts
+++ b/src/platform/config.ts
@@ -18,6 +18,8 @@ import { join } from "node:path";
 // Types
 // ---------------------------------------------------------------------------
 
+export type UpdateMode = "notify" | "auto" | "off";
+
 export interface Settings {
   server?: {
     /** Legacy field — kept for backward compat reading old settings.json */
@@ -47,6 +49,10 @@ export interface Settings {
   kb?: {
     /** Knowledge Base RAG REST API base URL (CAIPE_KB_URL overrides) */
     url?: string;
+  };
+  updates?: {
+    /** Daily CLI update behavior. Env override: CAIPE_UPDATE_MODE. */
+    mode?: UpdateMode;
   };
 }
 
@@ -266,6 +272,13 @@ export function getConfiguredDefaultAgent(): string | undefined {
   const fromSettings = readSettings().agent?.default;
   if (fromSettings && fromSettings.trim() !== "") return fromSettings.trim();
   return undefined;
+}
+
+/** Resolve update behavior. Priority: CAIPE_UPDATE_MODE → settings → notify. */
+export function getUpdateMode(): UpdateMode {
+  const env = process.env.CAIPE_UPDATE_MODE?.trim().toLowerCase();
+  if (env === "notify" || env === "auto" || env === "off") return env;
+  return readSettings().updates?.mode ?? "notify";
 }
 
 /**

--- a/src/platform/configcmd.ts
+++ b/src/platform/configcmd.ts
@@ -37,7 +37,7 @@ const SUPPORTED_KEYS: SupportedKey[] = [
 ];
 
 const CREDENTIAL_STORAGE_VALUES = ["encrypted-file", "keychain"] as const;
-const UPDATE_MODE_VALUES = ["notify", "auto", "off"] as const;
+const UPDATE_MODE_VALUES = ["auto", "notify", "off"] as const;
 
 function assertSupportedKey(key: string): asserts key is SupportedKey {
   if (!SUPPORTED_KEYS.includes(key as SupportedKey)) {
@@ -228,7 +228,7 @@ export async function runConfigGet(key: string, opts: { json?: boolean }): Promi
       value = envVal;
       source = "CAIPE_UPDATE_MODE env var";
     } else {
-      value = settings.updates?.mode ?? "notify";
+      value = settings.updates?.mode ?? "auto";
       source = settings.updates?.mode ? "settings.json" : "default";
     }
   }

--- a/src/platform/configcmd.ts
+++ b/src/platform/configcmd.ts
@@ -22,7 +22,8 @@ type SupportedKey =
   | "auth.credential-storage"
   | "auth.idp-hint"
   | "agent.default"
-  | "kb.url";
+  | "kb.url"
+  | "updates.mode";
 
 const SUPPORTED_KEYS: SupportedKey[] = [
   "auth.url",
@@ -32,9 +33,11 @@ const SUPPORTED_KEYS: SupportedKey[] = [
   "auth.idp-hint",
   "agent.default",
   "kb.url",
+  "updates.mode",
 ];
 
 const CREDENTIAL_STORAGE_VALUES = ["encrypted-file", "keychain"] as const;
+const UPDATE_MODE_VALUES = ["notify", "auto", "off"] as const;
 
 function assertSupportedKey(key: string): asserts key is SupportedKey {
   if (!SUPPORTED_KEYS.includes(key as SupportedKey)) {
@@ -146,6 +149,21 @@ export async function runConfigSet(key: string, value: string): Promise<void> {
     process.stdout.write(`Set kb.url = ${url}\n`);
     return;
   }
+
+  if (key === "updates.mode") {
+    const mode = value.trim().toLowerCase() as (typeof UPDATE_MODE_VALUES)[number];
+    if (!UPDATE_MODE_VALUES.includes(mode)) {
+      process.stderr.write(
+        `[ERROR] updates.mode must be one of: ${UPDATE_MODE_VALUES.join(", ")}\n`,
+      );
+      process.exit(3);
+    }
+    const settings = readSettings();
+    settings.updates = { ...settings.updates, mode };
+    writeSettings(settings);
+    process.stdout.write(`Set updates.mode = ${mode}\n`);
+    return;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -204,6 +222,15 @@ export async function runConfigGet(key: string, opts: { json?: boolean }): Promi
     } else {
       value = settings.kb?.url;
     }
+  } else if (key === "updates.mode") {
+    const envVal = process.env.CAIPE_UPDATE_MODE;
+    if (envVal) {
+      value = envVal;
+      source = "CAIPE_UPDATE_MODE env var";
+    } else {
+      value = settings.updates?.mode ?? "notify";
+      source = settings.updates?.mode ? "settings.json" : "default";
+    }
   }
 
   if (opts.json) {
@@ -251,6 +278,8 @@ export async function runConfigUnset(key: string): Promise<void> {
     settings.agent.default = undefined;
   } else if (key === "kb.url" && settings.kb) {
     settings.kb.url = undefined;
+  } else if (key === "updates.mode" && settings.updates) {
+    settings.updates.mode = undefined;
   }
 
   writeSettings(settings);

--- a/src/update/commands.ts
+++ b/src/update/commands.ts
@@ -1,0 +1,99 @@
+import { spawnSync } from "node:child_process";
+import semver from "semver";
+import {
+  type ReleaseInfo,
+  UpdateError,
+  fetchLatestRelease,
+  installReleaseBinary,
+  isUpdateAvailable,
+  releaseDownloads,
+  resolveInstallTarget,
+} from "./service.js";
+
+export interface UpdateCommandOptions {
+  check?: boolean;
+  force?: boolean;
+  json?: boolean;
+}
+
+interface UpdateResult {
+  currentVersion: string;
+  latestVersion: string;
+  updateAvailable: boolean;
+  installed: boolean;
+  releaseUrl: string;
+  installMethod?: "binary" | "npm";
+}
+
+function writeResult(result: UpdateResult, json: boolean): void {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return;
+  }
+  if (result.installed) {
+    process.stdout.write(`Updated caipe ${result.currentVersion} → ${result.latestVersion}.\n`);
+  } else if (result.updateAvailable) {
+    process.stdout.write(
+      `Update available: ${result.currentVersion} → ${result.latestVersion}\n${result.releaseUrl}\n`,
+    );
+  } else {
+    process.stdout.write(`caipe ${result.currentVersion} is up to date.\n`);
+  }
+}
+
+function updateWithNpm(release: ReleaseInfo): void {
+  const result = spawnSync("npm", ["install", "--global", `caipe@${release.version}`], {
+    stdio: "inherit",
+    env: { ...process.env, CAIPE_NO_UPDATE_CHECK: "1" },
+  });
+  if (result.error) throw new UpdateError(`Could not run npm: ${result.error.message}`);
+  if (result.status !== 0) {
+    throw new UpdateError(
+      `npm could not install caipe@${release.version}. Fix the npm error above and retry.`,
+    );
+  }
+}
+
+export async function runUpdate(
+  options: UpdateCommandOptions,
+  currentVersion: string,
+): Promise<void> {
+  try {
+    const release = await fetchLatestRelease();
+    releaseDownloads(release);
+    const available = isUpdateAvailable(currentVersion, release.version);
+    const base: UpdateResult = {
+      currentVersion,
+      latestVersion: release.version,
+      updateAvailable: available,
+      installed: false,
+      releaseUrl: release.url,
+    };
+    const reinstallCurrent = options.force === true && semver.eq(currentVersion, release.version);
+    if (options.check || (!available && !reinstallCurrent)) {
+      writeResult(base, options.json === true);
+      return;
+    }
+
+    const target = resolveInstallTarget();
+    if (target.kind === "unsupported") {
+      throw new UpdateError(
+        `${target.reason} Re-run setup-caipe-cli.sh to update this installation.`,
+      );
+    }
+    if (target.kind === "npm") {
+      updateWithNpm(release);
+    } else {
+      await installReleaseBinary(release, target.path);
+    }
+    writeResult({ ...base, installed: true, installMethod: target.kind }, options.json === true);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify({ error: detail, currentVersion })}\n`);
+    } else {
+      process.stderr.write(`[ERROR] ${detail}\n`);
+    }
+    process.exitCode = 3;
+  }
+}

--- a/src/update/service.ts
+++ b/src/update/service.ts
@@ -1,0 +1,267 @@
+import { spawnSync } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import { chmodSync, existsSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+import semver from "semver";
+
+export const UPDATE_REPOSITORY = "cnoe-io/caipe-cli";
+export const LATEST_RELEASE_API = `https://api.github.com/repos/${UPDATE_REPOSITORY}/releases/latest`;
+const MAX_DOWNLOAD_BYTES = 250 * 1024 * 1024;
+
+export interface ReleaseAsset {
+  name: string;
+  browserDownloadUrl: string;
+  size: number;
+}
+
+export interface ReleaseInfo {
+  version: string;
+  tag: string;
+  url: string;
+  assets: ReleaseAsset[];
+}
+
+export interface ReleaseDownloads {
+  binary: ReleaseAsset;
+  checksums: ReleaseAsset;
+}
+
+export type InstallTarget =
+  | { kind: "binary"; path: string }
+  | { kind: "npm" }
+  | { kind: "unsupported"; reason: string };
+
+interface GitHubReleaseResponse {
+  tag_name?: unknown;
+  html_url?: unknown;
+  prerelease?: unknown;
+  draft?: unknown;
+  assets?: unknown;
+}
+
+interface GitHubAssetResponse {
+  name?: unknown;
+  browser_download_url?: unknown;
+  size?: unknown;
+}
+
+export class UpdateError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UpdateError";
+  }
+}
+
+export function normalizeReleaseVersion(tag: string): string | null {
+  const normalized = tag
+    .trim()
+    .replace(/^caipe\//, "")
+    .replace(/^v/, "");
+  return semver.valid(normalized);
+}
+
+export function platformAssetName(platform = process.platform, arch = process.arch): string | null {
+  const os = platform === "darwin" ? "darwin" : platform === "linux" ? "linux" : null;
+  const cpu = arch === "arm64" ? "arm64" : arch === "x64" ? "x64" : null;
+  return os && cpu ? `caipe-${os}-${cpu}` : null;
+}
+
+export async function fetchLatestRelease(
+  fetchImpl: typeof fetch = fetch,
+  apiUrl = LATEST_RELEASE_API,
+): Promise<ReleaseInfo> {
+  const token = process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN;
+  const response = await fetchImpl(apiUrl, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      "User-Agent": "caipe-cli-update-check",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+    signal: AbortSignal.timeout(5_000),
+  });
+  if (!response.ok) {
+    throw new UpdateError(`GitHub release check failed (${response.status}).`);
+  }
+
+  const payload = (await response.json()) as GitHubReleaseResponse;
+  if (payload.draft === true || payload.prerelease === true) {
+    throw new UpdateError("GitHub returned a non-stable release as latest.");
+  }
+  if (typeof payload.tag_name !== "string" || typeof payload.html_url !== "string") {
+    throw new UpdateError("GitHub returned an invalid release payload.");
+  }
+  const version = normalizeReleaseVersion(payload.tag_name);
+  if (!version) throw new UpdateError(`Unsupported release tag: ${payload.tag_name}`);
+  if (!Array.isArray(payload.assets)) {
+    throw new UpdateError("GitHub release has no downloadable assets.");
+  }
+
+  const assets = payload.assets.flatMap((item): ReleaseAsset[] => {
+    if (!item || typeof item !== "object") return [];
+    const asset = item as GitHubAssetResponse;
+    if (
+      typeof asset.name !== "string" ||
+      typeof asset.browser_download_url !== "string" ||
+      typeof asset.size !== "number"
+    ) {
+      return [];
+    }
+    return [
+      {
+        name: asset.name,
+        browserDownloadUrl: asset.browser_download_url,
+        size: asset.size,
+      },
+    ];
+  });
+
+  return { version, tag: payload.tag_name, url: payload.html_url, assets };
+}
+
+export function releaseDownloads(
+  release: ReleaseInfo,
+  assetName = platformAssetName(),
+): ReleaseDownloads {
+  if (!assetName)
+    throw new UpdateError(`Unsupported platform: ${process.platform}/${process.arch}`);
+  const binary = release.assets.find((asset) => asset.name === assetName);
+  const checksums = release.assets.find((asset) => asset.name === "caipe-checksums.txt");
+  if (!binary || !checksums) {
+    throw new UpdateError(
+      `Release ${release.version} does not contain ${assetName} and caipe-checksums.txt.`,
+    );
+  }
+  return { binary, checksums };
+}
+
+export function isUpdateAvailable(currentVersion: string, latestVersion: string): boolean {
+  const current = semver.valid(currentVersion);
+  const latest = semver.valid(latestVersion);
+  if (!current || !latest) throw new UpdateError("Cannot compare invalid CLI release versions.");
+  return semver.gt(latest, current);
+}
+
+export function checksumForAsset(checksums: string, assetName: string): string | null {
+  for (const line of checksums.split(/\r?\n/)) {
+    const match = line.trim().match(/^([a-fA-F0-9]{64})\s+\*?(.+)$/);
+    if (match?.[2] === assetName) return match[1]?.toLowerCase() ?? null;
+  }
+  return null;
+}
+
+export function sha256(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+async function downloadBytes(asset: ReleaseAsset, fetchImpl: typeof fetch): Promise<Uint8Array> {
+  if (asset.size <= 0 || asset.size > MAX_DOWNLOAD_BYTES) {
+    throw new UpdateError(`Refusing unexpected download size for ${asset.name}: ${asset.size}.`);
+  }
+  const response = await fetchImpl(asset.browserDownloadUrl, {
+    headers: { "User-Agent": "caipe-cli-updater" },
+    redirect: "follow",
+    signal: AbortSignal.timeout(60_000),
+  });
+  if (!response.ok)
+    throw new UpdateError(`Download failed for ${asset.name} (${response.status}).`);
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  if (bytes.byteLength !== asset.size) {
+    throw new UpdateError(
+      `Download size mismatch for ${asset.name}: expected ${asset.size}, received ${bytes.byteLength}.`,
+    );
+  }
+  return bytes;
+}
+
+export async function downloadVerifiedBinary(
+  release: ReleaseInfo,
+  fetchImpl: typeof fetch = fetch,
+  assetName = platformAssetName(),
+): Promise<Uint8Array> {
+  const downloads = releaseDownloads(release, assetName);
+  const [binary, checksumBytes] = await Promise.all([
+    downloadBytes(downloads.binary, fetchImpl),
+    downloadBytes(downloads.checksums, fetchImpl),
+  ]);
+  const expected = checksumForAsset(new TextDecoder().decode(checksumBytes), downloads.binary.name);
+  if (!expected) {
+    throw new UpdateError(`No checksum published for ${downloads.binary.name}.`);
+  }
+  const actual = sha256(binary);
+  if (actual !== expected) {
+    throw new UpdateError(`Checksum verification failed for ${downloads.binary.name}.`);
+  }
+  return binary;
+}
+
+export function resolveInstallTarget(
+  input: {
+    env?: NodeJS.ProcessEnv;
+    execPath?: string;
+    isBun?: boolean;
+  } = {},
+): InstallTarget {
+  const env = input.env ?? process.env;
+  const execPath = input.execPath ?? process.execPath;
+  const isBun = input.isBun ?? Boolean(process.versions.bun);
+  if (env.CAIPE_INSTALL_METHOD === "npm") return { kind: "npm" };
+  if (env.CAIPE_BINARY_PATH) return { kind: "binary", path: env.CAIPE_BINARY_PATH };
+
+  const executable = basename(execPath);
+  if (isBun && (executable === "caipe" || /^caipe-(darwin|linux)-(arm64|x64)$/.test(executable))) {
+    return { kind: "binary", path: execPath };
+  }
+  return {
+    kind: "unsupported",
+    reason: "This installation is managed from source, a local package, or an unknown launcher.",
+  };
+}
+
+export type SmokeTest = (path: string, expectedVersion: string) => void;
+
+const defaultSmokeTest: SmokeTest = (path, expectedVersion) => {
+  const result = spawnSync(path, ["--version"], {
+    encoding: "utf8",
+    timeout: 10_000,
+    env: { ...process.env, CAIPE_NO_UPDATE_CHECK: "1" },
+  });
+  if (result.status !== 0 || result.stdout.trim() !== expectedVersion) {
+    throw new UpdateError(`Downloaded binary failed its version check for ${expectedVersion}.`);
+  }
+};
+
+export function installBinaryAtomically(
+  targetPath: string,
+  bytes: Uint8Array,
+  expectedVersion: string,
+  smokeTest: SmokeTest = defaultSmokeTest,
+): void {
+  const tempPath = join(
+    dirname(targetPath),
+    `.${basename(targetPath)}.update-${process.pid}-${randomBytes(6).toString("hex")}`,
+  );
+  try {
+    writeFileSync(tempPath, bytes, { flag: "wx", mode: 0o755 });
+    chmodSync(tempPath, 0o755);
+    smokeTest(tempPath, expectedVersion);
+    renameSync(tempPath, targetPath);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw error instanceof UpdateError
+      ? error
+      : new UpdateError(`Could not replace ${targetPath}: ${detail}`);
+  } finally {
+    if (existsSync(tempPath)) unlinkSync(tempPath);
+  }
+}
+
+export async function installReleaseBinary(
+  release: ReleaseInfo,
+  targetPath: string,
+  fetchImpl: typeof fetch = fetch,
+  smokeTest: SmokeTest = defaultSmokeTest,
+): Promise<void> {
+  const bytes = await downloadVerifiedBinary(release, fetchImpl);
+  installBinaryAtomically(targetPath, bytes, release.version, smokeTest);
+}

--- a/src/update/startup.ts
+++ b/src/update/startup.ts
@@ -1,0 +1,89 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { type UpdateMode, getUpdateMode, globalConfigDir } from "../platform/config.js";
+import {
+  fetchLatestRelease,
+  installReleaseBinary,
+  isUpdateAvailable,
+  releaseDownloads,
+  resolveInstallTarget,
+} from "./service.js";
+
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1_000;
+
+interface UpdateState {
+  lastCheckedAt?: string;
+  lastNotifiedVersion?: string;
+}
+
+export function updateStatePath(): string {
+  return join(globalConfigDir(), "update-state.json");
+}
+
+function readUpdateState(): UpdateState {
+  const path = updateStatePath();
+  if (!existsSync(path)) return {};
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as UpdateState;
+  } catch {
+    return {};
+  }
+}
+
+function writeUpdateState(state: UpdateState): void {
+  const path = updateStatePath();
+  mkdirSync(dirname(path), { recursive: true });
+  const temp = `${path}.${process.pid}.tmp`;
+  writeFileSync(temp, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
+  renameSync(temp, path);
+}
+
+export function updateCheckIsDue(state: UpdateState, now = Date.now()): boolean {
+  if (!state.lastCheckedAt) return true;
+  const checkedAt = Date.parse(state.lastCheckedAt);
+  return !Number.isFinite(checkedAt) || now - checkedAt >= CHECK_INTERVAL_MS;
+}
+
+function startupCheckEnabled(mode: UpdateMode): boolean {
+  return (
+    mode !== "off" &&
+    process.env.CAIPE_NO_UPDATE_CHECK !== "1" &&
+    process.env.CI !== "true" &&
+    process.stderr.isTTY === true
+  );
+}
+
+export async function maybeRunStartupUpdate(currentVersion: string): Promise<void> {
+  const mode = getUpdateMode();
+  if (!startupCheckEnabled(mode)) return;
+  const state = readUpdateState();
+  if (!updateCheckIsDue(state)) return;
+
+  const nextState: UpdateState = { ...state, lastCheckedAt: new Date().toISOString() };
+  writeUpdateState(nextState);
+  try {
+    const release = await fetchLatestRelease();
+    releaseDownloads(release);
+    if (!isUpdateAvailable(currentVersion, release.version)) return;
+
+    if (mode === "auto") {
+      const target = resolveInstallTarget();
+      if (target.kind === "binary") {
+        await installReleaseBinary(release, target.path);
+        process.stderr.write(
+          `\n[caipe] Updated to ${release.version}; the new version will run next time.\n`,
+        );
+        return;
+      }
+    }
+
+    if (state.lastNotifiedVersion !== release.version) {
+      process.stderr.write(
+        `\n[caipe] Update available: ${currentVersion} → ${release.version}. Run \`caipe update\`.\n`,
+      );
+      writeUpdateState({ ...nextState, lastNotifiedVersion: release.version });
+    }
+  } catch {
+    // Startup update checks are best-effort and must never block normal CLI use.
+  }
+}

--- a/tests/cli.e2e.test.ts
+++ b/tests/cli.e2e.test.ts
@@ -45,6 +45,7 @@ describe("bin/caipe.cjs", () => {
     });
     expect(exitCode).toBe(0);
     expect(stdout).toMatch(/chat|config|auth/i);
+    expect(stdout).toContain("update");
   });
 });
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -96,6 +96,10 @@ describe("settings read/write", () => {
     expect(s.updates?.mode).toBe("auto");
   });
 
+  it("defaults updates.mode to auto", () => {
+    expect(getUpdateMode()).toBe("auto");
+  });
+
   it("lets CAIPE_UPDATE_MODE override settings", () => {
     writeSettings({ updates: { mode: "notify" } });
     process.env.CAIPE_UPDATE_MODE = "off";

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -26,12 +26,14 @@ beforeEach(() => {
   // Clear URL env vars — must use empty string, not undefined (which becomes "undefined")
   process.env.CAIPE_AUTH_URL = "";
   process.env.CAIPE_SERVER_URL = "";
+  process.env.CAIPE_UPDATE_MODE = "";
 });
 
 afterEach(() => {
   process.env.XDG_CONFIG_HOME = "";
   process.env.CAIPE_AUTH_URL = "";
   process.env.CAIPE_SERVER_URL = "";
+  process.env.CAIPE_UPDATE_MODE = "";
   if (existsSync(testDir)) {
     rmSync(testDir, { recursive: true, force: true });
   }
@@ -46,6 +48,7 @@ import {
   ServerNotConfigured,
   getAuthUrl,
   getServerUrl,
+  getUpdateMode,
   globalConfigDir,
   readSettings,
   settingsJsonPath,
@@ -85,6 +88,18 @@ describe("settings read/write", () => {
     writeSettings({ agent: { default: "agent-sre" } });
     const s = readSettings();
     expect(s.agent?.default).toBe("agent-sre");
+  });
+
+  it("round-trips updates.mode", () => {
+    writeSettings({ updates: { mode: "auto" } });
+    const s = readSettings();
+    expect(s.updates?.mode).toBe("auto");
+  });
+
+  it("lets CAIPE_UPDATE_MODE override settings", () => {
+    writeSettings({ updates: { mode: "notify" } });
+    process.env.CAIPE_UPDATE_MODE = "off";
+    expect(getUpdateMode()).toBe("off");
   });
 
   it("handles corrupted settings file gracefully", () => {

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -1,0 +1,175 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  type ReleaseInfo,
+  checksumForAsset,
+  downloadVerifiedBinary,
+  fetchLatestRelease,
+  installBinaryAtomically,
+  isUpdateAvailable,
+  normalizeReleaseVersion,
+  platformAssetName,
+  resolveInstallTarget,
+  sha256,
+} from "../src/update/service";
+import { updateCheckIsDue } from "../src/update/startup";
+
+const cleanup: string[] = [];
+
+afterEach(() => {
+  for (const path of cleanup.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+function release(assets: ReleaseInfo["assets"] = []): ReleaseInfo {
+  return {
+    version: "1.2.0",
+    tag: "v1.2.0",
+    url: "https://example.com/releases/1.2.0",
+    assets,
+  };
+}
+
+describe("release discovery", () => {
+  it("normalizes supported tag formats and compares versions", () => {
+    expect(normalizeReleaseVersion("caipe/v1.2.3")).toBe("1.2.3");
+    expect(normalizeReleaseVersion("v1.2.3")).toBe("1.2.3");
+    expect(normalizeReleaseVersion("not-a-version")).toBeNull();
+    expect(isUpdateAvailable("1.1.9", "1.2.0")).toBe(true);
+    expect(isUpdateAvailable("1.2.0", "1.2.0")).toBe(false);
+  });
+
+  it("maps supported platforms to release asset names", () => {
+    expect(platformAssetName("darwin", "arm64")).toBe("caipe-darwin-arm64");
+    expect(platformAssetName("linux", "x64")).toBe("caipe-linux-x64");
+    expect(platformAssetName("win32", "x64")).toBeNull();
+  });
+
+  it("parses a stable GitHub release payload", async () => {
+    const fetchImpl = (async () =>
+      new Response(
+        JSON.stringify({
+          tag_name: "v1.2.0",
+          html_url: "https://example.com/releases/1.2.0",
+          draft: false,
+          prerelease: false,
+          assets: [
+            {
+              name: "caipe-linux-x64",
+              browser_download_url: "https://example.com/caipe-linux-x64",
+              size: 4,
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )) as typeof fetch;
+
+    const found = await fetchLatestRelease(fetchImpl, "https://api.example.com/releases/latest");
+    expect(found.version).toBe("1.2.0");
+    expect(found.assets[0]?.name).toBe("caipe-linux-x64");
+  });
+});
+
+describe("verified update downloads", () => {
+  it("accepts a binary only when its published checksum matches", async () => {
+    const binary = new TextEncoder().encode("safe-binary");
+    const checksums = new TextEncoder().encode(`${sha256(binary)}  caipe-linux-x64\n`);
+    const info = release([
+      {
+        name: "caipe-linux-x64",
+        browserDownloadUrl: "https://example.com/caipe-linux-x64",
+        size: binary.byteLength,
+      },
+      {
+        name: "caipe-checksums.txt",
+        browserDownloadUrl: "https://example.com/caipe-checksums.txt",
+        size: checksums.byteLength,
+      },
+    ]);
+    const fetchImpl = (async (input: string | URL | Request) => {
+      const url = String(input);
+      const body = url.endsWith("checksums.txt") ? checksums : binary;
+      return new Response(body, { status: 200 });
+    }) as typeof fetch;
+
+    await expect(downloadVerifiedBinary(info, fetchImpl, "caipe-linux-x64")).resolves.toEqual(
+      binary,
+    );
+    expect(checksumForAsset(new TextDecoder().decode(checksums), "caipe-linux-x64")).toBe(
+      sha256(binary),
+    );
+  });
+
+  it("rejects a checksum mismatch", async () => {
+    const binary = new TextEncoder().encode("tampered");
+    const checksums = new TextEncoder().encode(`${"0".repeat(64)}  caipe-linux-x64\n`);
+    const info = release([
+      {
+        name: "caipe-linux-x64",
+        browserDownloadUrl: "https://example.com/caipe-linux-x64",
+        size: binary.byteLength,
+      },
+      {
+        name: "caipe-checksums.txt",
+        browserDownloadUrl: "https://example.com/caipe-checksums.txt",
+        size: checksums.byteLength,
+      },
+    ]);
+    const fetchImpl = (async (input: string | URL | Request) =>
+      new Response(String(input).endsWith("checksums.txt") ? checksums : binary, {
+        status: 200,
+      })) as typeof fetch;
+
+    await expect(downloadVerifiedBinary(info, fetchImpl, "caipe-linux-x64")).rejects.toThrow(
+      /checksum verification failed/i,
+    );
+  });
+});
+
+describe("installation", () => {
+  it("smoke-tests and atomically replaces the current binary", () => {
+    const dir = mkdtempSync(join(tmpdir(), "caipe-update-"));
+    cleanup.push(dir);
+    const target = join(dir, "caipe");
+    writeFileSync(target, "old");
+    const next = new TextEncoder().encode("new");
+
+    installBinaryAtomically(target, next, "1.2.0", (candidate, expectedVersion) => {
+      expect(readFileSync(candidate, "utf8")).toBe("new");
+      expect(expectedVersion).toBe("1.2.0");
+    });
+
+    expect(readFileSync(target, "utf8")).toBe("new");
+    expect(existsSync(target)).toBe(true);
+  });
+
+  it("distinguishes npm, known binary, and source installs", () => {
+    expect(
+      resolveInstallTarget({
+        env: { CAIPE_INSTALL_METHOD: "npm" },
+        execPath: "/usr/bin/node",
+        isBun: false,
+      }),
+    ).toEqual({ kind: "npm" });
+    expect(
+      resolveInstallTarget({
+        env: { CAIPE_BINARY_PATH: "/opt/caipe/caipe-linux-x64" },
+        execPath: "/usr/bin/node",
+        isBun: false,
+      }),
+    ).toEqual({ kind: "binary", path: "/opt/caipe/caipe-linux-x64" });
+    expect(resolveInstallTarget({ env: {}, execPath: "/usr/bin/node", isBun: false }).kind).toBe(
+      "unsupported",
+    );
+  });
+});
+
+describe("startup update cadence", () => {
+  it("checks at most once per day", () => {
+    const now = Date.parse("2026-08-13T12:00:00Z");
+    expect(updateCheckIsDue({}, now)).toBe(true);
+    expect(updateCheckIsDue({ lastCheckedAt: "2026-08-13T11:00:00Z" }, now)).toBe(false);
+    expect(updateCheckIsDue({ lastCheckedAt: "2026-08-12T11:00:00Z" }, now)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- add `caipe update`, `--check`, `--force`, and JSON output
- check for stable releases once per day when interactive chat starts
- default verified binary installs to automatic updates; retain `notify` and `off` as explicit opt-outs
- detect binary, global npm, local package, and source installation provenance before mutating anything
- verify release asset size and SHA-256 checksum, smoke-test `--version`, then replace binaries atomically
- make explicit npm updates delegate to npm without silently elevating privileges
- tag and publish every successful `main` commit as the next patch release

## Release safety

- gate automatic releases on the complete `main` CI workflow
- serialize release preparation so concurrent merges cannot select the same version
- reuse an existing commit tag when rerun instead of creating a duplicate
- stamp the resolved tag version into compiled binaries and npm packages
- require both the platform binary and `caipe-checksums.txt`
- propagate install provenance from the npm and release launchers
- throttle checks in `~/.config/caipe/update-state.json`
- support `CAIPE_UPDATE_MODE` and `CAIPE_NO_UPDATE_CHECK=1`

The first automatic release will continue the existing repository tags at `0.2.22`. It will make the multi-architecture assets required by the updater available.

## Testing

- `actionlint`
- automatic tag calculation simulation (expected `0.2.22`)
- `bun run lint` (passes with 18 existing warnings)
- `bunx tsc --noEmit`
- `bun run test` (222 tests)
- `bun build src/index.ts --outdir /tmp/caipe-cli-auto-update-final --target node --external keytar --external fsevents`
- compiled macOS arm64 binary smoke test
- `node --check bin/caipe.cjs`
- `shellcheck install.sh setup-caipe-cli.sh`
