### PR TITLE
ci(release): publish every successful main commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,20 +6,117 @@ on:
       - "[0-9]*.[0-9]*.[0-9]*"
       - "v[0-9]*.[0-9]*.[0-9]*"
       - "caipe/v[0-9]*.[0-9]*.[0-9]*"
+  workflow_run:
+    workflows:
+      - caipe CLI CI
+    types:
+      - completed
+    branches:
+      - main
 
 permissions:
   contents: read
 
 concurrency:
-  group: publish-${{ github.ref }}
+  # Serialize main releases so simultaneous merges cannot select the same patch.
+  group: publish-${{ github.event_name == 'workflow_run' && 'main' || github.ref }}
   cancel-in-progress: false
 
 jobs:
+  prepare:
+    name: Prepare release tag
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    outputs:
+      tag: ${{ steps.release.outputs.tag }}
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
+          fetch-depth: 0
+
+      - name: Resolve release tag
+        id: release
+        shell: bash
+        env:
+          RELEASE_EVENT: ${{ github.event_name }}
+          MAIN_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          normalize_tag() {
+            local value="${1#caipe/}"
+            printf '%s\n' "${value#v}"
+          }
+
+          if [[ "$RELEASE_EVENT" != "workflow_run" ]]; then
+            tag="$GITHUB_REF_NAME"
+            version="$(normalize_tag "$tag")"
+          else
+            existing_tag="$({
+              git tag --points-at "$MAIN_SHA" \
+                | grep -E '^(caipe/)?v?[0-9]+\.[0-9]+\.[0-9]+$' \
+                | sort -V \
+                | tail -n 1
+            } || true)"
+
+            if [[ -n "$existing_tag" ]]; then
+              tag="$existing_tag"
+              version="$(normalize_tag "$tag")"
+              echo "Reusing $tag already attached to $MAIN_SHA"
+            else
+              package_version="$(node -p "require('./package.json').version")"
+              if [[ ! "$package_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                echo "package.json must contain a stable semantic version: $package_version" >&2
+                exit 1
+              fi
+
+              latest_version="$({
+                git tag --list \
+                  | sed -En 's#^(caipe/)?v?([0-9]+\.[0-9]+\.[0-9]+)$#\2#p' \
+                  | sort -V \
+                  | tail -n 1
+              } || true)"
+
+              if [[ -z "$latest_version" ]]; then
+                version="$package_version"
+              else
+                highest_version="$(printf '%s\n%s\n' "$latest_version" "$package_version" | sort -V | tail -n 1)"
+                if [[ "$highest_version" == "$package_version" && "$package_version" != "$latest_version" ]]; then
+                  version="$package_version"
+                else
+                  IFS=. read -r major minor patch <<< "$latest_version"
+                  version="${major}.${minor}.$((patch + 1))"
+                fi
+              fi
+
+              tag="$version"
+              git config user.name "github-actions[bot]"
+              git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+              git tag --annotate "$tag" "$MAIN_SHA" --message "caipe CLI $tag"
+              git push origin "refs/tags/$tag"
+              echo "Created $tag for $MAIN_SHA"
+            fi
+          fi
+
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Unsupported release tag: $tag" >&2
+            exit 1
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
   verify:
     name: Verify release source
+    needs: prepare
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
 
       - name: Install Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
@@ -29,16 +126,10 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Verify package version matches tag
-        shell: bash
-        run: |
-          tag="${GITHUB_REF_NAME#caipe/}"
-          release_version="${tag#v}"
-          package_version="$(node -p "require('./package.json').version")"
-          test "$package_version" = "$release_version" || {
-            echo "package.json version $package_version does not match tag $release_version" >&2
-            exit 1
-          }
+      - name: Stamp release version
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: npm version "$VERSION" --no-git-tag-version --allow-same-version
 
       - name: Type check
         run: bun tsc --noEmit
@@ -51,7 +142,7 @@ jobs:
 
   build:
     name: Build ${{ matrix.artifact }}
-    needs: verify
+    needs: [prepare, verify]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -72,6 +163,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
 
       - name: Install Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
@@ -80,6 +173,11 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      - name: Stamp release version
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: npm version "$VERSION" --no-git-tag-version --allow-same-version
 
       - name: Compile single-file binary
         run: |
@@ -123,14 +221,17 @@ jobs:
 
   release:
     name: Publish GitHub Release
-    needs: build
+    needs: [prepare, build]
     runs-on: ubuntu-24.04
     permissions:
       contents: write
     outputs:
-      version: ${{ steps.version.outputs.version }}
+      tag: ${{ needs.prepare.outputs.tag }}
+      version: ${{ needs.prepare.outputs.version }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
 
       - name: Download release artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
@@ -138,18 +239,6 @@ jobs:
           pattern: release-*
           path: dist
           merge-multiple: true
-
-      - name: Validate tag and extract version
-        id: version
-        shell: bash
-        run: |
-          tag="${GITHUB_REF_NAME#caipe/}"
-          version="${tag#v}"
-          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
-            echo "Unsupported release tag: ${GITHUB_REF_NAME}" >&2
-            exit 1
-          fi
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Merge checksums
         run: |
@@ -161,15 +250,15 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
         with:
-          tag_name: ${{ github.ref_name }}
-          name: caipe CLI v${{ steps.version.outputs.version }}
+          tag_name: ${{ needs.prepare.outputs.tag }}
+          name: caipe CLI v${{ needs.prepare.outputs.version }}
           body: |
             ## Install
 
             Published npm package (automatic platform selection):
 
             ```bash
-            npm install -g caipe@${{ steps.version.outputs.version }}
+            npm install -g caipe@${{ needs.prepare.outputs.version }}
             caipe --version
             ```
 
@@ -188,7 +277,7 @@ jobs:
             dist/caipe-checksums.txt
           fail_on_unmatched_files: true
           draft: false
-          prerelease: ${{ contains(steps.version.outputs.version, '-') }}
+          prerelease: ${{ contains(needs.prepare.outputs.version, '-') }}
           generate_release_notes: true
 
   sign:
@@ -222,7 +311,7 @@ jobs:
       - name: Upload signatures
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ needs.release.outputs.tag }}
           REPO: ${{ github.repository }}
         run: |
           for artifact in caipe-darwin-arm64 caipe-darwin-x64 caipe-linux-arm64 caipe-linux-x64; do
@@ -245,6 +334,8 @@ jobs:
       NPM_CONFIG_USERCONFIG: ${{ github.workspace }}/.npmrc
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: ${{ needs.release.outputs.tag }}
 
       - name: Download release artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ caipe config set updates.mode notify  # auto (default), notify, or off
 Source or unknown launchers fall back to a notification and an actionable
 manual update command. Set `CAIPE_NO_UPDATE_CHECK=1` for a one-off invocation.
 
+Every commit to `main` is released after the full CI workflow succeeds. The
+release workflow creates the next patch tag, publishes checksummed binaries,
+signs them with cosign, and publishes the matching npm packages.
+
 ---
 
 ## Developer guide


### PR DESCRIPTION
## Summary

- trigger the release workflow after the full `main` CI workflow succeeds
- serialize tag calculation so simultaneous merges cannot select the same patch version
- create an annotated semantic-version tag on the exact `main` commit
- stamp the resolved version into compiled binaries and npm packages
- preserve manually pushed stable and prerelease tags
- reuse an existing commit tag on reruns

## Release behavior

The first automatic tag will be `0.2.22`, continuing after the existing `0.2.21` tag. Each subsequent successful `main` commit increments the patch version and publishes the existing checksummed, cosign-signed, multi-architecture GitHub and npm release.

This avoids release-only commits and does not rely on a tag pushed with `GITHUB_TOKEN` starting a second workflow.

## Validation

- `actionlint`
- automatic tag calculation simulation (expected `0.2.22`)
- `bunx tsc --noEmit`
- `bun run lint` (passes with 18 existing warnings)
- `bun run test` (222 tests)

Related: #44