### PR TITLE
fix(installer): avoid latest release API lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,15 @@ bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/caipe-cli/main/setup
 Then verify the installation with `caipe --version`. If `~/.local/bin` is not
 already on your `PATH`, the setup script prints the exact command to add it.
 
-The npm package and downloadable release binaries are not published yet. Do
-not use `npm install caipe`, `npx github:cnoe-io/caipe-cli`, or `install.sh`
-until the first multi-architecture release is available.
+The installer downloads the latest multi-architecture GitHub release and
+verifies its SHA-256 checksum. Pin a release when reproducibility matters:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/cnoe-io/caipe-cli/main/install.sh \
+  | CAIPE_VERSION=0.2.22 sh
+```
+
+The npm package is not published yet; use `install.sh` until it is available.
 
 ### Updates
 

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,8 @@ set -e
 
 REPO="cnoe-io/caipe-cli"
 INSTALL_DIR="${CAIPE_INSTALL_DIR:-/usr/local/bin}"
-VERSION="${CAIPE_VERSION:-}"
+DEFAULT_VERSION="latest"
+VERSION="${CAIPE_VERSION:-$DEFAULT_VERSION}"
 TAG=""
 NO_VERIFY="${CAIPE_NO_VERIFY:-0}"
 
@@ -55,35 +56,25 @@ detect_platform() {
 # ── resolve latest version ────────────────────────────────────────────────────
 
 resolve_version() {
-  if [ -n "$VERSION" ]; then
+  if [ "$VERSION" != "$DEFAULT_VERSION" ]; then
     TAG="$VERSION"
     info "Using pinned version: $VERSION"
     return
   fi
 
-  info "Resolving latest release…"
-  need_cmd curl
-
-  TAG=$(curl -fsSL \
-    "https://api.github.com/repos/${REPO}/releases/latest" \
-    | grep '"tag_name"' \
-    | head -1 \
-    | sed 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
-
-  if [ -z "$TAG" ]; then
-    die "Could not determine latest caipe release. Set CAIPE_VERSION to install a specific version."
-  fi
-
-  VERSION="${TAG#caipe/}"
-  VERSION="${VERSION#v}"
-  info "Latest version: $VERSION"
+  info "Using latest release"
 }
 
 # ── download and verify ───────────────────────────────────────────────────────
 
 download_binary() {
   BINARY_NAME="caipe-${PLATFORM}"
-  BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
+  if [ -n "$TAG" ]; then
+    BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
+  else
+    # This redirect is not subject to the unauthenticated GitHub API rate limit.
+    BASE_URL="https://github.com/${REPO}/releases/latest/download"
+  fi
   BINARY_URL="${BASE_URL}/${BINARY_NAME}"
   CHECKSUMS_URL="${BASE_URL}/caipe-checksums.txt"
 

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const installer = readFileSync(new URL("../install.sh", import.meta.url), "utf8");
+
+describe("release installer", () => {
+  it("uses the API-free latest-release redirect by default", () => {
+    expect(installer).toContain('DEFAULT_VERSION="latest"');
+    expect(installer).toContain('BASE_URL="https://github.com/${REPO}/releases/latest/download"');
+    expect(installer).not.toContain("api.github.com");
+  });
+
+  it("keeps explicit version pins on immutable release URLs", () => {
+    expect(installer).toContain('BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"');
+  });
+});


### PR DESCRIPTION
## Summary

- make `latest` the installer default in the repository
- download default binaries and checksums through GitHub release redirects
- keep `CAIPE_VERSION` support for immutable version-pinned installs
- remove the unauthenticated GitHub API call that can return HTTP 403
- update stale release installation documentation
- add regression tests for latest and pinned URL behavior

## Root cause

The installer queried the unauthenticated GitHub Releases API only to discover the newest tag. GitHub can rate-limit that endpoint with HTTP 403 even though the public release assets remain downloadable.

## Validation

- `shellcheck install.sh`
- `bunx tsc --noEmit`
- `bun run lint` (passes with 18 existing warnings)
- `bun run test` (224 tests)
- isolated end-to-end latest install with checksum verification; installed `0.2.22`
- latest binary and checksum redirect endpoints return HTTP 200
