### PR TITLE
feat(installer): default to user-local directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Terminal client for [CAIPE](https://github.com/cnoe-io/ai-platform-engineering):
 curl -fsSL https://raw.githubusercontent.com/cnoe-io/caipe-cli/main/install.sh | sh
 ```
 
-The installer downloads the latest verified release to your home directory and
-adds the `caipe` launcher to `~/.local/bin`. It does not need `sudo` unless you
-explicitly select a system directory.
+The installer downloads the latest verified release and asks where to place the
+`caipe` launcher. Press Enter for `~/.local/bin` (recommended, no password),
+choose `~/.bin`, or explicitly select `/usr/local/bin` for a system-wide install.
 
 **Point at your CAIPE deployment, sign in, chat:**
 
@@ -46,10 +46,19 @@ Optional: **keytar** only if you set `auth.credential-storage` to `keychain`.
 curl -fsSL https://raw.githubusercontent.com/cnoe-io/caipe-cli/main/install.sh | sh
 ```
 
-Then verify the installation with `caipe --version`. If `~/.local/bin` is not
-already on your `PATH`, the installer prints the exact command to add it.
+The installer asks you to choose:
 
-Choose another user-owned directory without a password:
+1. `~/.local/bin` — recommended, no password
+2. `~/.bin` — user-owned alternative, no password
+3. `/usr/local/bin` — system-wide and may require `sudo`
+
+Press Enter to accept option 1. In a non-interactive environment, option 1 is
+selected automatically. Then verify with `caipe --version`. If the selected
+directory is not already on `PATH`, the installer prints the exact command to
+add it.
+
+Automation can bypass the prompt with `CAIPE_INSTALL_DIR`. For example, choose
+the user-owned `~/.bin` directory without a password:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/cnoe-io/caipe-cli/main/install.sh \

--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@ Terminal client for [CAIPE](https://github.com/cnoe-io/ai-platform-engineering):
 **Install CAIPE CLI:**
 
 ```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/caipe-cli/main/setup-caipe-cli.sh)
+curl -fsSL https://raw.githubusercontent.com/cnoe-io/caipe-cli/main/install.sh | sh
 ```
 
-The setup script installs Bun when needed, builds CAIPE CLI from the latest
-`main`, and adds `caipe` to `~/.local/bin`.
+The installer downloads the latest verified release to your home directory and
+adds the `caipe` launcher to `~/.local/bin`. It does not need `sudo` unless you
+explicitly select a system directory.
 
 **Point at your CAIPE deployment, sign in, chat:**
 
@@ -32,7 +33,7 @@ Other host (UI serves OAuth on the same URL): set only `server.url`, then `caipe
 ---
 
 - macOS or Linux on arm64 or x64
-- `curl` and `git` (Bun is installed by the setup script when needed)
+- `curl` and Node.js 20 or newer
 - A reachable CAIPE deployment (API + OAuth)
 
 Optional: **keytar** only if you set `auth.credential-storage` to `keychain`.
@@ -42,11 +43,29 @@ Optional: **keytar** only if you set `auth.credential-storage` to `keychain`.
 ## Install
 
 ```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/caipe-cli/main/setup-caipe-cli.sh)
+curl -fsSL https://raw.githubusercontent.com/cnoe-io/caipe-cli/main/install.sh | sh
 ```
 
 Then verify the installation with `caipe --version`. If `~/.local/bin` is not
-already on your `PATH`, the setup script prints the exact command to add it.
+already on your `PATH`, the installer prints the exact command to add it.
+
+Choose another user-owned directory without a password:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/cnoe-io/caipe-cli/main/install.sh \
+  | CAIPE_INSTALL_DIR="$HOME/.bin" sh
+```
+
+Choose a system-wide directory explicitly. The installer asks for `sudo` only
+when that directory is not writable:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/cnoe-io/caipe-cli/main/install.sh \
+  | CAIPE_INSTALL_DIR=/usr/local/bin sh
+```
+
+In every case, `CAIPE_INSTALL_DIR` controls only the small launcher on `PATH`;
+the platform binary is stored under `~/.local/share/caipe` by default.
 
 The installer downloads the latest multi-architecture GitHub release and
 verifies its SHA-256 checksum. Pin a release when reproducibility matters:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ curl -fsSL https://raw.githubusercontent.com/cnoe-io/caipe-cli/main/install.sh |
 
 The installer downloads the latest verified release and asks where to place the
 `caipe` launcher. Press Enter for `~/.local/bin` (recommended, no password),
-choose `~/.bin`, or explicitly select `/usr/local/bin` for a system-wide install.
+choose `~/.bin`, or stage a launcher for an explicit system-wide install. The
+web-fetched script never invokes `sudo` or reads a password.
 
 **Point at your CAIPE deployment, sign in, chat:**
 
@@ -50,7 +51,7 @@ The installer asks you to choose:
 
 1. `~/.local/bin` — recommended, no password
 2. `~/.bin` — user-owned alternative, no password
-3. `/usr/local/bin` — system-wide and may require `sudo`
+3. `/usr/local/bin` — stages the launcher and prints separate review/install commands
 
 Press Enter to accept option 1. In a non-interactive environment, option 1 is
 selected automatically. Then verify with `caipe --version`. If the selected
@@ -65,13 +66,17 @@ curl -fsSL https://raw.githubusercontent.com/cnoe-io/caipe-cli/main/install.sh \
   | CAIPE_INSTALL_DIR="$HOME/.bin" sh
 ```
 
-Choose a system-wide directory explicitly. The installer asks for `sudo` only
-when that directory is not writable:
+Choose a system-wide directory explicitly:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/cnoe-io/caipe-cli/main/install.sh \
   | CAIPE_INSTALL_DIR=/usr/local/bin sh
 ```
+
+The web installer downloads and verifies the binary, stages the launcher under
+`~/.local/share/caipe`, and stops. It never invokes `sudo`. Review the staged
+launcher, then separately run the exact `sudo mkdir` and `sudo install` commands
+it prints.
 
 In every case, `CAIPE_INSTALL_DIR` controls only the small launcher on `PATH`;
 the platform binary is stored under `~/.local/share/caipe` by default.

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@
 #   curl -fsSL https://raw.githubusercontent.com/cnoe-io/caipe-cli/main/install.sh | sh
 #
 # Options (environment variables):
-#   CAIPE_INSTALL_DIR   — override install directory (default: /usr/local/bin)
+#   CAIPE_INSTALL_DIR   — launcher directory (default: $HOME/.local/bin)
 #   CAIPE_VERSION       — pin a specific version (default: latest)
 #   CAIPE_NO_VERIFY     — set to 1 to skip checksum verification (not recommended)
 #
@@ -14,7 +14,7 @@
 set -e
 
 REPO="cnoe-io/caipe-cli"
-INSTALL_DIR="${CAIPE_INSTALL_DIR:-/usr/local/bin}"
+INSTALL_DIR="${CAIPE_INSTALL_DIR:-${HOME}/.local/bin}"
 DEFAULT_VERSION="latest"
 VERSION="${CAIPE_VERSION:-$DEFAULT_VERSION}"
 TAG=""
@@ -165,6 +165,17 @@ process.exit(r.status ?? (r.signal ? 128 : 1));
 LAUNCHER_EOF
   chmod +x "${LAUNCHER}"
 
+  if [ ! -d "$INSTALL_DIR" ]; then
+    if ! mkdir -p "$INSTALL_DIR" 2>/dev/null; then
+      info "Creating ${INSTALL_DIR} requires elevated privileges…"
+      if command -v sudo >/dev/null 2>&1; then
+        sudo mkdir -p "$INSTALL_DIR"
+      else
+        die "Cannot create ${INSTALL_DIR}. Set CAIPE_INSTALL_DIR to a writable directory."
+      fi
+    fi
+  fi
+
   if [ ! -w "$INSTALL_DIR" ]; then
     info "Installing to ${INSTALL_DIR} requires elevated privileges…"
     if command -v sudo >/dev/null 2>&1; then
@@ -208,6 +219,7 @@ main() {
 
   detect_platform
   resolve_version
+  info "Install directory: ${INSTALL_DIR}"
   download_binary
   install_binary
   verify_install

--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,7 @@ DEFAULT_VERSION="latest"
 VERSION="${CAIPE_VERSION:-$DEFAULT_VERSION}"
 TAG=""
 NO_VERIFY="${CAIPE_NO_VERIFY:-0}"
+INSTALL_PENDING="0"
 
 # ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -53,7 +54,7 @@ choose_install_dir() {
   printf '\nWhere should caipe be installed?\n' >/dev/tty
   printf '  1) %s  (recommended, no password)\n' "$DEFAULT_INSTALL_DIR" >/dev/tty
   printf '  2) %s  (no password)\n' "${HOME}/.bin" >/dev/tty
-  printf '  3) /usr/local/bin  (system-wide; may ask for a password)\n' >/dev/tty
+  printf '  3) /usr/local/bin  (system-wide; completed with a separate command)\n' >/dev/tty
   printf 'Select [1]: ' >/dev/tty
 
   choice=""
@@ -201,23 +202,14 @@ LAUNCHER_EOF
 
   if [ ! -d "$INSTALL_DIR" ]; then
     if ! mkdir -p "$INSTALL_DIR" 2>/dev/null; then
-      info "Creating ${INSTALL_DIR} requires elevated privileges…"
-      if command -v sudo >/dev/null 2>&1; then
-        sudo mkdir -p "$INSTALL_DIR"
-      else
-        die "Cannot create ${INSTALL_DIR}. Set CAIPE_INSTALL_DIR to a writable directory."
-      fi
+      stage_privileged_launcher
+      return
     fi
   fi
 
   if [ ! -w "$INSTALL_DIR" ]; then
-    info "Installing to ${INSTALL_DIR} requires elevated privileges…"
-    if command -v sudo >/dev/null 2>&1; then
-      sudo install -m 755 "${LAUNCHER}" "${DEST}"
-    else
-      die "Cannot write to ${INSTALL_DIR} and sudo is unavailable. " \
-          "Set CAIPE_INSTALL_DIR to a writable directory (e.g. ~/.local/bin)."
-    fi
+    stage_privileged_launcher
+    return
   else
     install -m 755 "${LAUNCHER}" "${DEST}"
   fi
@@ -225,9 +217,26 @@ LAUNCHER_EOF
   ok "Installed caipe launcher to ${DEST}"
 }
 
+stage_privileged_launcher() {
+  STAGED_LAUNCHER="${SHARE}/caipe-launcher"
+  install -m 755 "${LAUNCHER}" "${STAGED_LAUNCHER}"
+  INSTALL_PENDING="1"
+
+  printf '\n\033[33m  ! The web installer never runs sudo.\033[0m\n'
+  printf '    Review the staged launcher:\n'
+  printf '      less "%s"\n\n' "$STAGED_LAUNCHER"
+  printf '    Then complete the system-wide install yourself:\n'
+  printf '      sudo mkdir -p "%s"\n' "$INSTALL_DIR"
+  printf '      sudo install -m 755 "%s" "%s"\n\n' "$STAGED_LAUNCHER" "$DEST"
+}
+
 # ── verify installation ───────────────────────────────────────────────────────
 
 verify_install() {
+  if [ "$INSTALL_PENDING" = "1" ]; then
+    return
+  fi
+
   if ! command -v caipe >/dev/null 2>&1; then
     printf '\n\033[33m  ! caipe is not in your PATH.\033[0m\n'
     printf '    Add %s to your PATH:\n' "$INSTALL_DIR"
@@ -258,6 +267,12 @@ main() {
   download_binary
   install_binary
   verify_install
+
+  if [ "$INSTALL_PENDING" = "1" ]; then
+    printf '\n\033[32mDownload and verification complete.\033[0m\n'
+    printf 'Run the reviewed system-install commands shown above to finish.\n\n'
+    return
+  fi
 
   printf '\n\033[32mInstallation complete!\033[0m\n'
   printf 'Get started:\n'

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,8 @@
 set -e
 
 REPO="cnoe-io/caipe-cli"
-INSTALL_DIR="${CAIPE_INSTALL_DIR:-${HOME}/.local/bin}"
+DEFAULT_INSTALL_DIR="${HOME}/.local/bin"
+INSTALL_DIR="${CAIPE_INSTALL_DIR:-}"
 DEFAULT_VERSION="latest"
 VERSION="${CAIPE_VERSION:-$DEFAULT_VERSION}"
 TAG=""
@@ -30,6 +31,39 @@ need_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
     die "Required command not found: $1"
   fi
+}
+
+can_prompt() {
+  [ -c /dev/tty ] || return 1
+  { : </dev/tty; } 2>/dev/null
+}
+
+choose_install_dir() {
+  # An explicit environment value is authoritative and keeps automation quiet.
+  if [ -n "$INSTALL_DIR" ]; then
+    return
+  fi
+
+  INSTALL_DIR="$DEFAULT_INSTALL_DIR"
+  if ! can_prompt; then
+    info "No interactive terminal; using ${INSTALL_DIR}"
+    return
+  fi
+
+  printf '\nWhere should caipe be installed?\n' >/dev/tty
+  printf '  1) %s  (recommended, no password)\n' "$DEFAULT_INSTALL_DIR" >/dev/tty
+  printf '  2) %s  (no password)\n' "${HOME}/.bin" >/dev/tty
+  printf '  3) /usr/local/bin  (system-wide; may ask for a password)\n' >/dev/tty
+  printf 'Select [1]: ' >/dev/tty
+
+  choice=""
+  IFS= read -r choice </dev/tty || true
+  case "$choice" in
+    ""|1) INSTALL_DIR="$DEFAULT_INSTALL_DIR" ;;
+    2) INSTALL_DIR="${HOME}/.bin" ;;
+    3) INSTALL_DIR="/usr/local/bin" ;;
+    *) die "Invalid selection: ${choice}. Choose 1, 2, or 3." ;;
+  esac
 }
 
 # ── detect platform ───────────────────────────────────────────────────────────
@@ -219,6 +253,7 @@ main() {
 
   detect_platform
   resolve_version
+  choose_install_dir
   info "Install directory: ${INSTALL_DIR}"
   download_binary
   install_binary

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -13,6 +13,12 @@ describe("release installer", () => {
     expect(installer).not.toContain("CAIPE_INSTALL_DIR:-/usr/local/bin");
   });
 
+  it("never elevates privileges inside the web-fetched script", () => {
+    expect(installer).toContain("The web installer never runs sudo.");
+    expect(installer).not.toContain("command -v sudo");
+    expect(installer).not.toMatch(/^\s*sudo\s/m);
+  });
+
   it("uses the API-free latest-release redirect by default", () => {
     expect(installer).toContain('DEFAULT_VERSION="latest"');
     expect(installer).toContain('BASE_URL="https://github.com/${REPO}/releases/latest/download"');

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -4,8 +4,12 @@ import { describe, expect, it } from "vitest";
 const installer = readFileSync(new URL("../install.sh", import.meta.url), "utf8");
 
 describe("release installer", () => {
-  it("installs the launcher in a user-owned directory by default", () => {
-    expect(installer).toContain('INSTALL_DIR="${CAIPE_INSTALL_DIR:-${HOME}/.local/bin}"');
+  it("offers user-owned directories before the system-wide directory", () => {
+    expect(installer).toContain('DEFAULT_INSTALL_DIR="${HOME}/.local/bin"');
+    expect(installer).toContain('INSTALL_DIR="${CAIPE_INSTALL_DIR:-}"');
+    expect(installer).toContain("Where should caipe be installed?");
+    expect(installer).toContain('2) INSTALL_DIR="${HOME}/.bin"');
+    expect(installer).toContain('3) INSTALL_DIR="/usr/local/bin"');
     expect(installer).not.toContain("CAIPE_INSTALL_DIR:-/usr/local/bin");
   });
 

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -4,6 +4,11 @@ import { describe, expect, it } from "vitest";
 const installer = readFileSync(new URL("../install.sh", import.meta.url), "utf8");
 
 describe("release installer", () => {
+  it("installs the launcher in a user-owned directory by default", () => {
+    expect(installer).toContain('INSTALL_DIR="${CAIPE_INSTALL_DIR:-${HOME}/.local/bin}"');
+    expect(installer).not.toContain("CAIPE_INSTALL_DIR:-/usr/local/bin");
+  });
+
   it("uses the API-free latest-release redirect by default", () => {
     expect(installer).toContain('DEFAULT_VERSION="latest"');
     expect(installer).toContain('BASE_URL="https://github.com/${REPO}/releases/latest/download"');


### PR DESCRIPTION
## Summary

- prompt interactive users to choose `~/.local/bin`, `~/.bin`, or `/usr/local/bin`
- recommend the passwordless `~/.local/bin` option and select it on Enter
- default non-interactive installs to `~/.local/bin`
- preserve `CAIPE_INSTALL_DIR` as an authoritative prompt-free override for automation
- never invoke `sudo` from the web-fetched installer
- stage the launcher for unwritable or system directories and print separate review/install commands
- show the resolved install directory before downloading
- update the primary installation documentation and examples

## Security boundary

The piped installer always runs as the current user. For an unwritable system-wide target it:

1. downloads and verifies the release binary
2. stages the launcher in `~/.local/share/caipe`
3. stops without elevating privileges
4. prints a `less` review command and separate `sudo mkdir` / `sudo install` commands for the user to run deliberately

## User experience

The standard command asks where to install:

```text
Where should caipe be installed?
  1) ~/.local/bin   (recommended, no password)
  2) ~/.bin         (no password)
  3) /usr/local/bin (system-wide; completed with a separate command)
Select [1]:
```

Piped installation reads the choice from the controlling terminal. CI and other non-interactive environments safely use option 1. Setting `CAIPE_INSTALL_DIR` bypasses the prompt.

## Validation

- `shellcheck install.sh`
- `bunx tsc --noEmit`
- `bun run lint` (passes with 18 existing warnings)
- `bun run test` (226 tests)
- interactive terminal installation selecting option 2
- unwritable system-target staging end to end
- checksum verified against release `0.2.23`
- verified no executable source line begins with `sudo`
